### PR TITLE
Refine CI workflow and README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install black ruff pytest
+      - name: Black check
+        run: black --check .
+      - name: Ruff lint
+        run: ruff check .
+      - name: Pytest
+        run: pytest
+      - name: Pytest coverage check (placeholder)
+        run: echo "TODO: enforce coverage thresholds"
+  js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+      - name: Jest
+        run: npm test --if-present
+      - name: Jest coverage check (placeholder)
+        run: echo "TODO: enforce coverage thresholds"

--- a/README.MD
+++ b/README.MD
@@ -1,1 +1,3 @@
-README.MD
+# ZEUSNET
+
+This repository includes a basic GitHub Actions workflow for linting and testing Python and JavaScript code. The workflow runs Black, Ruff, Pytest and Jest, with placeholders for future coverage enforcement. Lint or test errors cause the workflow to fail.


### PR DESCRIPTION
## Summary
- tweak Ruff invocation in CI to use `ruff check`
- expand README overview of CI and coverage placeholders

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q` *(no tests ran)*
- `npm test --if-present` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c2d80384c832490b7ae3f896d742f