### PR TITLE
Add alerts and command API routes

### DIFF
--- a/backend/api/alerts.py
+++ b/backend/api/alerts.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from backend.db import get_db
+from backend.alerts.anomaly import detect_anomalies
+from backend.alerts.mac_tracker import track_devices
+from backend.alerts.rogue_ap import detect_rogue_aps
+
+router = APIRouter()
+
+
+@router.get("/alerts")
+def get_alerts(db: Session = Depends(get_db)):
+    """Aggregate all alert types into a single list."""
+    alerts = []
+    alerts.extend(detect_anomalies(db))
+    alerts.extend(detect_rogue_aps(db))
+    alerts.extend(track_devices(db))
+    return alerts

--- a/backend/api/command.py
+++ b/backend/api/command.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from backend.c2.command_bus import command_bus
+
+router = APIRouter()
+
+
+class CommandModel(BaseModel):
+    opcode: int
+    payload: dict | None = None
+
+
+@router.post("/command")
+def send_command(cmd: CommandModel):
+    command_bus.send(cmd.opcode, cmd.payload)
+    return {"status": "sent"}

--- a/backend/db.py
+++ b/backend/db.py
@@ -5,3 +5,12 @@ from backend.settings import DATABASE_URL
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine, autoflush=False)
 Base = declarative_base()
+
+
+def get_db():
+    """Yield a new SQLAlchemy session and ensure closure."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
-from backend.api import scan, networks, devices, export
-from backend.alerts import anomaly, rogue_ap, mac_tracker
+from backend.api import scan, networks, devices, export, alerts, command
+from backend.c2.command_bus import start_bus
 
 app = FastAPI()
 
@@ -9,3 +9,10 @@ app.include_router(scan.router, prefix="/api")
 app.include_router(networks.router, prefix="/api")
 app.include_router(devices.router, prefix="/api")
 app.include_router(export.router, prefix="/api")
+app.include_router(alerts.router, prefix="/api")
+app.include_router(command.router, prefix="/api")
+
+
+@app.on_event("startup")
+def _startup():
+    start_bus()

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -5,3 +5,9 @@ load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///zeusnet.db")
 ZEUSNET_MODE = os.getenv("ZEUSNET_MODE", "SAFE")
+
+# Serial and MQTT defaults for command bus
+SERIAL_PORT = os.getenv("SERIAL_PORT", "/dev/ttyUSB0")
+SERIAL_BAUD = int(os.getenv("SERIAL_BAUD", "115200"))
+MQTT_BROKER = os.getenv("MQTT_BROKER", "localhost")
+MQTT_TOPIC = os.getenv("MQTT_TOPIC", "zeusnet")

--- a/esp32/zeusnet_esp32.ino
+++ b/esp32/zeusnet_esp32.ino
@@ -2,7 +2,7 @@
 #include "macros.h"
 
 #define SERIAL_BAUD 115200
-#define SCAN_INTERVAL 5000
+unsigned long scanInterval = 5000;
 
 unsigned long lastScan = 0;
 
@@ -14,7 +14,7 @@ void setup() {
 }
 
 void loop() {
-  if (millis() - lastScan > SCAN_INTERVAL) {
+  if (millis() - lastScan > scanInterval) {
     scanAndSend();
     lastScan = millis();
   }
@@ -62,6 +62,6 @@ void handleCommand() {
   if (cmd == "REBOOT") {
     ESP.restart();
   } else if (cmd.startsWith("SET_INTERVAL:")) {
-    SCAN_INTERVAL = cmd.substring(13).toInt();
+    scanInterval = cmd.substring(13).toInt();
   }
 }


### PR DESCRIPTION
## Summary
- expose new `/alerts` endpoint combining anomaly, rogue AP, and device tracking alerts
- implement `/command` endpoint to relay commands to the ESP32
- provide database session helper via `get_db`
- configure serial and MQTT settings defaults
- ensure command bus starts with the backend
- fix mutable scan interval in ESP32 firmware

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c4850bf7c832498fc31bf30452e62