### PR TITLE
Add cross-platform launch scripts and Docker MQTT

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -48,6 +48,17 @@ npm install
 npm start
 ```
 
+### Cross-Platform Docker MQTT
+
+To avoid installing Mosquitto manually, run it via Docker:
+
+```bash
+docker compose up -d mqtt
+```
+
+Then launch everything with `start-zeusnet.sh` (or `.bat` on Windows). See
+`docs/setup.md` for full setup instructions.
+
 ### Flash ESP32
 
 ```bash

--- a/backend/c2/command_bus.py
+++ b/backend/c2/command_bus.py
@@ -21,10 +21,7 @@ class SerialCommandBus:
         self.read_thread.start()
 
     def send(self, opcode: int, payload: dict = None):
-        packet = {
-            "opcode": opcode,
-            "payload": payload or {}
-        }
+        packet = {"opcode": opcode, "payload": payload or {}}
         raw = json.dumps(packet).encode("utf-8") + b"\n"
         self.ser.write(raw)
         logger.debug(f"[SerialBus] Sent to ESP32: {packet}")
@@ -92,6 +89,7 @@ class MQTTCommandRelay:
 # Entrypoint for integration
 command_bus = SerialCommandBus()
 mqtt_relay = MQTTCommandRelay(command_bus)
+
 
 def start_bus():
     command_bus.start()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from backend.api import scan, networks, devices, export, alerts, command
+from backend.routes import networks as demo_networks
 from backend.c2.command_bus import start_bus
 
 app = FastAPI()
@@ -7,6 +8,7 @@ app = FastAPI()
 # Routers
 app.include_router(scan.router, prefix="/api")
 app.include_router(networks.router, prefix="/api")
+app.include_router(demo_networks.router)
 app.include_router(devices.router, prefix="/api")
 app.include_router(export.router, prefix="/api")
 app.include_router(alerts.router, prefix="/api")

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, Integer, String, DateTime
 from backend.db import Base  # ✅ Use your project's Base
 from datetime import datetime
 
+
 class DeviceSeen(Base):
     __tablename__ = "device_seen"
 
@@ -10,6 +11,7 @@ class DeviceSeen(Base):
     ssid = Column(String, nullable=True)
     signal_strength = Column(Integer, nullable=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
+
 
 class WiFiScan(Base):
     __tablename__ = "wifi_scans"
@@ -22,6 +24,7 @@ class WiFiScan(Base):
     channel = Column(Integer)
     timestamp = Column(DateTime, default=datetime.utcnow)
 
+
 class Device(Base):
     __tablename__ = "devices"
 
@@ -29,6 +32,7 @@ class Device(Base):
     mac = Column(String, unique=True, index=True)
     first_seen = Column(DateTime)
     last_seen = Column(DateTime)
+
 
 class Alert(Base):
     __tablename__ = "alerts"

--- a/backend/routes/networks.py
+++ b/backend/routes/networks.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/networks")
+async def get_networks(limit: int = 50):
+    return [{"ssid": f"ZeusNet-{i}", "rssi": -30 - i} for i in range(limit)]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  mqtt:
+    image: eclipse-mosquitto
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./docker/mosquitto.conf:/mosquitto/config/mosquitto.conf

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,24 @@
+## ZeusNet Dev Setup
+
+### 🛠 Requirements
+- Python 3.10+
+- Node.js 20+
+- Docker
+- Virtualenv or venv
+
+### 🔄 Quickstart
+```bash
+git clone https://github.com/your/zeusnet.git
+cd zeusnet
+python -m venv .venv
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+pip install -r backend/requirements.txt
+npm install --prefix frontend
+docker compose up -d mqtt
+```
+
+### 🚀 Launch
+
+```bash
+bash start-zeusnet.sh  # or start-zeusnet.bat on Windows
+```

--- a/start-zeusnet.bat
+++ b/start-zeusnet.bat
@@ -1,0 +1,14 @@
+@echo off
+
+cd backend
+if exist ..\.venv\Scripts\activate.bat (
+    call ..\.venv\Scripts\activate.bat
+)
+start uvicorn main:app --reload
+cd ..
+
+docker compose up -d mqtt
+
+cd frontend
+npm run dev
+

--- a/start-zeusnet.sh
+++ b/start-zeusnet.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+echo "Starting ZeusNet Backend..."
+cd backend
+if [ -d ../.venv ]; then
+    source ../.venv/bin/activate
+fi
+uvicorn main:app --reload &
+cd ..
+
+echo "Starting MQTT broker..."
+docker compose up -d mqtt
+
+echo "Starting ZeusNet Frontend..."
+cd frontend
+npm run dev
+


### PR DESCRIPTION
## Summary
- enable Dockerized MQTT with config and compose file
- add demo networks router and register it
- document setup and cross-platform MQTT usage
- provide start scripts for Linux/macOS and Windows
- format code with black

## Testing
- `black --check .`
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c835fb4d08324a13aef04221d24b5