### PR TITLE
Improve GTK UI for live network data

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -68,6 +68,8 @@ python gtk_app/main.py
 ```
 
 This requires the `PyGObject` package built with GTK **4**.
+The window now displays SSID, BSSID, channel, authentication mode,
+RSSI and timestamp, refreshing every few seconds.
 
 ### Auto Start with systemd (Linux)
 


### PR DESCRIPTION
## Summary
- extend GTK viewer to show BSSID, channel, auth and time
- run a background asyncio loop for smoother updates
- document desktop app refresh behaviour in README

## Testing
- `python -m py_compile gtk_app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d2c2515dc8324b941276018c6cb41