### PR TITLE
Fix network API crash and create DB on startup

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -38,6 +38,7 @@ cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn main:app --reload
+# Tables are created automatically on first run
 ```
 
 ### Frontend (React)
@@ -68,6 +69,9 @@ python gtk_app/main.py
 ```
 
 This requires the `PyGObject` package built with GTK **4**.
+The window now displays SSID, BSSID, channel, authentication mode,
+RSSI and timestamp, refreshing every few seconds. A status bar
+indicates the time of the last successful update or any errors.
 
 ### Auto Start with systemd (Linux)
 

--- a/backend/api/networks.py
+++ b/backend/api/networks.py
@@ -9,4 +9,15 @@ router = APIRouter()
 @router.get("/networks")
 def get_networks(limit: int = Query(50, le=500), db: Session = Depends(get_db)):
     scans = db.query(WiFiScan).order_by(WiFiScan.timestamp.desc()).limit(limit).all()
-    return [s.__dict__ for s in scans]
+    return [
+        {
+            "id": s.id,
+            "ssid": s.ssid,
+            "bssid": s.bssid,
+            "rssi": s.rssi,
+            "auth": s.auth,
+            "channel": s.channel,
+            "timestamp": s.timestamp,
+        }
+        for s in scans
+    ]

--- a/backend/db.py
+++ b/backend/db.py
@@ -7,6 +7,11 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False)
 Base = declarative_base()
 
 
+def init_db():
+    """Create database tables if they do not exist."""
+    Base.metadata.create_all(engine)
+
+
 def get_db():
     """Yield a new SQLAlchemy session and ensure closure."""
     db = SessionLocal()

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from backend.api import (
 from fastapi.middleware.cors import CORSMiddleware
 from backend.routes import networks as demo_networks
 from backend.c2.command_bus import start_bus
+from backend.db import init_db
 
 app = FastAPI(
     title="ZeusNet API",
@@ -54,4 +55,5 @@ app.include_router(diagnostic.router, prefix="/api")
 # 🚀 Background startup tasks
 @app.on_event("startup")
 def _startup():
+    init_db()
     start_bus()

--- a/gtk_app/main.py
+++ b/gtk_app/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import gi
 import aiohttp
 
@@ -10,26 +11,44 @@ API_URL = "http://localhost:8000/api/networks?limit=50"
 class NetworkWindow(Gtk.ApplicationWindow):
     def __init__(self, app: Gtk.Application):
         super().__init__(application=app, title="ZeusNet GTK")
-        self.set_default_size(400, 300)
+        self.set_default_size(600, 400)
 
-        self.liststore = Gtk.ListStore(str, int)
+        # Store: SSID, BSSID, Channel, RSSI, Auth, Time
+        self.liststore = Gtk.ListStore(str, str, int, int, str, str)
         treeview = Gtk.TreeView(model=self.liststore)
-        renderer_text = Gtk.CellRendererText()
-        column_text = Gtk.TreeViewColumn("SSID", renderer_text, text=0)
-        treeview.append_column(column_text)
-        renderer_rssi = Gtk.CellRendererText()
-        column_rssi = Gtk.TreeViewColumn("RSSI", renderer_rssi, text=1)
-        treeview.append_column(column_rssi)
+
+        columns = [
+            ("SSID", 0),
+            ("BSSID", 1),
+            ("CH", 2),
+            ("RSSI", 3),
+            ("AUTH", 4),
+            ("TIME", 5),
+        ]
+        for title, idx in columns:
+            renderer = Gtk.CellRendererText()
+            treeview.append_column(Gtk.TreeViewColumn(title, renderer, text=idx))
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_child(treeview)
-        self.set_child(scrolled)
+
+        # Status label showing last update or errors
+        self.status_label = Gtk.Label(xalign=0)
+
+        container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        container.append(scrolled)
+        container.append(self.status_label)
+        self.set_child(container)
+
+        # Dedicated asyncio loop in a background thread
+        self.loop = asyncio.new_event_loop()
+        threading.Thread(target=self.loop.run_forever, daemon=True).start()
 
         GLib.timeout_add_seconds(5, self.refresh)
 
         # First fetch on load
-        asyncio.get_event_loop().create_task(self.fetch())
+        asyncio.run_coroutine_threadsafe(self.fetch(), self.loop)
 
     async def fetch(self):
         try:
@@ -37,18 +56,43 @@ class NetworkWindow(Gtk.ApplicationWindow):
                 async with session.get(API_URL) as resp:
                     if resp.status == 200:
                         data = await resp.json()
-                        self.liststore.clear()
-                        for item in data:
-                            self.liststore.append(
-                                [item.get("ssid", "Unknown"), item.get("rssi", 0)]
-                            )
+                        GLib.idle_add(self.update_store, data)
+                        GLib.idle_add(
+                            self.update_status,
+                            f"Last update: {len(data)} networks",
+                        )
                     else:
-                        print(f"HTTP Error: {resp.status}")
+                        GLib.idle_add(
+                            self.update_status,
+                            f"HTTP Error: {resp.status}",
+                        )
         except Exception as e:
-            print("Error fetching networks:", e)
+            GLib.idle_add(self.update_status, f"Error: {e}")
+
+    def update_store(self, data):
+        """Update Gtk.ListStore from a background thread."""
+        self.liststore.clear()
+        for item in data:
+            timestamp = item.get("timestamp", "")
+            if isinstance(timestamp, str):
+                timestamp = timestamp.replace("T", " ").split(".")[0]
+            self.liststore.append([
+                item.get("ssid", "Unknown"),
+                item.get("bssid", "N/A"),
+                item.get("channel", 0),
+                item.get("rssi", 0),
+                item.get("auth", ""),
+                timestamp,
+            ])
+        return False
+
+    def update_status(self, text: str):
+        """Update status label safely from any thread."""
+        self.status_label.set_text(text)
+        return False
 
     def refresh(self):
-        asyncio.get_event_loop().create_task(self.fetch())
+        asyncio.run_coroutine_threadsafe(self.fetch(), self.loop)
         return True
 
 


### PR DESCRIPTION
## Summary
- create database tables on startup
- properly serialize Wi-Fi scans in `/api/networks`
- document that tables are auto-created when the backend starts

## Testing
- `python -m py_compile backend/*.py backend/api/*.py gtk_app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685d2c2515dc8324b941276018c6cb41