### PR TITLE
Add React-based web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ frontend/dist/
 
 # compress esp32-ZeusNet driver
 esp32-ZeusNet.zip
+webui/dist/

--- a/README.MD
+++ b/README.MD
@@ -50,6 +50,14 @@ uvicorn main:app --reload
 python frontend/main.py
 ```
 
+### Web UI (React)
+
+```bash
+cd webui
+npm install
+npm run dev
+```
+
 ### Cross-Platform Docker MQTT
 
 To avoid installing Mosquitto manually, run it via Docker:
@@ -116,6 +124,7 @@ ZeusNet/
 │   └── c2/               # Command bus
 ├── frontend/             # GTK UI
 │   └── main.py          # Desktop application
+├── webui/                # React web interface
 ```
 
 ## ⚠️ Mode Switching

--- a/backend/api/nic.py
+++ b/backend/api/nic.py
@@ -19,7 +19,9 @@ class AttackService:
     def __init__(self):
         self.active: dict[int, dict] = {}
 
-    def _build_command(self, mode: str, target: str | None, channel: int | None) -> list[str]:
+    def _build_command(
+        self, mode: str, target: str | None, channel: int | None
+    ) -> list[str]:
         if mode == "deauth" and target:
             return ["echo", f"deauth {target}"]
         if mode == "rogue_ap":

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -34,4 +34,3 @@ def update_settings(data: SettingsUpdate):
         config.SERIAL_BAUD = data.serial_baud
         os.environ["SERIAL_BAUD"] = str(data.serial_baud)
     return get_settings()
-

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ app = FastAPI(
     description="Secure, Real-Time Network Analysis and Control System",
 )
 
+
 # 👋 Root endpoint for friendly browser access
 @app.get("/")
 def read_root():
@@ -34,6 +35,7 @@ def read_root():
         "command": "/api/command",
         "export_csv": "/api/export/csv",
     }
+
 
 # 🌐 Add CORS support for frontend dev
 app.add_middleware(
@@ -55,6 +57,7 @@ app.include_router(command.router, prefix="/api")
 app.include_router(settings_api.router, prefix="/api")
 app.include_router(nic.router, prefix="/api")
 app.include_router(diagnostic.router, prefix="/api")
+
 
 # 🚀 Background startup tasks
 @app.on_event("startup")

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,6 +32,16 @@ python frontend/main.py
 
 Requires the `PyGObject` package with GTK **4** support.
 
+### 🌐 Web UI (React)
+
+Run the browser-based dashboard with Vite:
+
+```bash
+cd webui
+npm install
+npm run dev
+```
+
 ### ⚙️ Enable systemd Service (Optional)
 
 ```bash

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -10,11 +10,11 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk, GLib, GdkPixbuf
+from gi.repository import Gtk, GLib, GdkPixbuf  # noqa: E402
 
 try:
     gi.require_version("WebKit2", "4.0")
-    from gi.repository import WebKit2
+    from gi.repository import WebKit2  # noqa: E402
 except Exception:  # pragma: no cover - optional dependency
     WebKit2 = None
 

--- a/tree.txt
+++ b/tree.txt
@@ -28,3 +28,4 @@
 ├── 📁 frontend
 │   └── 📄 main.py
 ├── 📄 requirements.txt 
+├── 📁 webui

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZeusNet Control Center</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "zeusnet-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.3",
+    "vite": "^4.4.9"
+  }
+}

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import ModeToggle from "./components/ModeToggle";
+import AttackForm from "./components/AttackForm";
+import TerminalLog from "./components/TerminalLog";
+
+export default function App() {
+  const [mode, setMode] = useState("SAFE");
+  const [logLines, setLogLines] = useState([]);
+
+  const log = (msg) =>
+    setLogLines((lines) => [...lines, `[${new Date().toLocaleTimeString()}] ${msg}`]);
+
+  return (
+    <div className="dashboard">
+      <h1>ZeusNet Control Center</h1>
+      <ModeToggle mode={mode} setMode={setMode} />
+      <AttackForm log={log} />
+      <TerminalLog lines={logLines} />
+    </div>
+  );
+}

--- a/webui/src/components/AttackForm.jsx
+++ b/webui/src/components/AttackForm.jsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { sendAttack } from "../utils/api";
+
+export default function AttackForm({ log }) {
+  const [mode, setMode] = useState("deauth");
+  const [target, setTarget] = useState("");
+  const [channel, setChannel] = useState(6);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    log(`Firing ${mode.toUpperCase()} on ${target} @ ch ${channel}`);
+
+    try {
+      const res = await sendAttack({ mode, target, channel });
+      log(JSON.stringify(res, null, 2));
+    } catch (err) {
+      log(`❌ ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>Attack Type</label>
+      <select value={mode} onChange={(e) => setMode(e.target.value)}>
+        <option value="deauth">Deauth</option>
+        <option value="pmkid">PMKID Capture</option>
+        <option value="rogue_ap">Rogue AP</option>
+      </select>
+
+      {(mode === "deauth" || mode === "rogue_ap") && (
+        <>
+          <label>Target MAC</label>
+          <input
+            type="text"
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            required={mode === "deauth"}
+          />
+        </>
+      )}
+
+      <label>Channel</label>
+      <input
+        type="number"
+        value={channel}
+        onChange={(e) => setChannel(e.target.value)}
+      />
+
+      <button disabled={loading}>{loading ? "Deploying..." : "Launch Attack"}</button>
+    </form>
+  );
+}

--- a/webui/src/components/ModeToggle.jsx
+++ b/webui/src/components/ModeToggle.jsx
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+export default function ModeToggle({ mode, setMode }) {
+  return (
+    <div className="toggle-container">
+      <label>Mode:</label>
+      <select value={mode} onChange={(e) => setMode(e.target.value)}>
+        <option value="SAFE">SAFE</option>
+        <option value="AGGRESSIVE">AGGRESSIVE</option>
+      </select>
+    </div>
+  );
+}

--- a/webui/src/components/TerminalLog.jsx
+++ b/webui/src/components/TerminalLog.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from "react";
+
+export default function TerminalLog({ lines }) {
+  const endRef = useRef();
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [lines]);
+
+  return (
+    <div className="terminal">
+      {lines.map((line, i) => (
+        <div key={i}>{line}</div>
+      ))}
+      <div ref={endRef} />
+    </div>
+  );
+}

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./style.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);

--- a/webui/src/style.css
+++ b/webui/src/style.css
@@ -1,0 +1,37 @@
+body {
+  font-family: monospace;
+  background: #0d1117;
+  color: #c9d1d9;
+  padding: 2rem;
+}
+
+.dashboard {
+  max-width: 600px;
+  margin: auto;
+}
+
+form,
+.toggle-container {
+  margin-bottom: 1rem;
+}
+
+input,
+select,
+button {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  background: #161b22;
+  color: white;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+}
+
+.terminal {
+  background: #161b22;
+  border: 1px solid #30363d;
+  height: 200px;
+  overflow-y: auto;
+  padding: 1rem;
+}

--- a/webui/src/utils/api.js
+++ b/webui/src/utils/api.js
@@ -1,0 +1,14 @@
+export async function sendAttack({ mode, target, channel }) {
+  const res = await fetch("/api/nic/attack", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mode, target, channel }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.detail || "Unknown error");
+  }
+
+  return await res.json();
+}

--- a/webui/vite.config.js
+++ b/webui/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+})


### PR DESCRIPTION
## Summary
- create `webui` Vite React app with attack controls
- document new web UI usage in README and setup guide
- ignore webui build artifacts
- update Python backend formatting

## Testing
- `ruff check .`
- `black --check .`
- `pytest`
- `npm test` *(fails to install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d789d2ae88324b6b2c26ab498db8b