### PR TITLE
Port GTK frontend to GTK4

### DIFF
--- a/frontend/main.py
+++ b/frontend/main.py
@@ -215,15 +215,8 @@ class NetworkWindow(Gtk.ApplicationWindow):
         
         dashboard_page = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
         dashboard_page.append(self.chart_image)
-        self.notebook.append_page(dashboard_page, Gtk.Label(label="Dashboard"))
 
-        # ----- Map tab -----
-        if WEBKIT_AVAILABLE:
-            self.webview = WebKit2.WebView()
-            map_container = self.webview
-        else:
-            self.webview = None
-            map_container = Gtk.Label(label="WebKit2 not available")
+        self.notebook.append_page(dashboard_page, Gtk.Label(label="Dashboard"))
 
     def _create_map_tab(self):
         """Create the map tab (if WebKit is available)."""
@@ -550,11 +543,6 @@ class NetworkWindow(Gtk.ApplicationWindow):
         loader.close()
         self.chart_image.set_from_pixbuf(loader.get_pixbuf())
 
-    def draw_map(self, data: list[dict]):
-        if not WEBKIT_AVAILABLE:
-            return
-        import folium
-
     def draw_map(self, data: List[Dict[str, Any]]) -> None:
         """Draw the network map (if WebKit is available)."""
         if not WEBKIT_AVAILABLE or not data:
@@ -603,10 +591,7 @@ class NetworkWindow(Gtk.ApplicationWindow):
 
 class ZeusApp(Gtk.Application):
     def __init__(self):
-        super().__init__(
-            application_id="com.zeusnet.viewer",
-            flags=Gtk.ApplicationFlags.DEFAULT_FLAGS
-        )
+        super().__init__(application_id="com.zeusnet.viewer")
         
     def do_activate(self) -> None:
         """Application activation handler."""
@@ -617,7 +602,7 @@ class ZeusApp(Gtk.Application):
 def main() -> None:
     """Main entry point."""
     app = ZeusApp()
-    exit_status = app.run(None)
+    exit_status = app.run()
     raise SystemExit(exit_status)
 
 


### PR DESCRIPTION
## Summary
- drop deprecated Gtk.ApplicationFlags usage
- clean up dashboard/map tab creation
- remove stale draw_map stub
- run the application with GTK4 `run()` API

## Testing
- `python -m py_compile frontend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d986a786883249755b33343ca3037