### PR TITLE
Improve production deployment docs and scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend backend
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.MD
+++ b/README.MD
@@ -40,7 +40,7 @@ ESP32 (Spectral Scanner / Captive Portal)
 cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn main:app --reload
+ZEUSNET_ENV=dev uvicorn main:app --reload
 # Tables are created automatically on first run
 ```
 
@@ -63,11 +63,14 @@ npm run dev
 To avoid installing Mosquitto manually, run it via Docker:
 
 ```bash
-docker compose up -d mqtt
+docker compose up -d backend mqtt
 ```
 
-Then launch everything with `start-zeusnet.sh` (or `.bat` on Windows). See
-`docs/setup.md` for full setup instructions.
+This spins up the FastAPI backend in a lightweight container along with
+Mosquitto. See `docs/setup.md` for full setup instructions.
+
+To run the stack locally without Docker Compose, set `ZEUSNET_ENV=dev` and
+execute `start-zeusnet.sh` (or `.bat` on Windows).
 
 ### GTK Desktop UI
 
@@ -96,7 +99,9 @@ sudo systemctl enable zeusnet-serial
 sudo systemctl start zeusnet-serial
 ```
 
-The service uses a cached serial port stored under `~/.config/zeusnet/last_serial`.
+The service assumes ZeusNet is installed under `/opt/zeusnet` and reads
+environment variables from `/opt/zeusnet/.env`. It caches the last detected
+serial port under `~/.config/zeusnet/last_serial`.
 ### Flash ESP32
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,9 @@ services:
       - "1883:1883"
     volumes:
       - ./docker/mosquitto.conf:/mosquitto/config/mosquitto.conf
+  backend:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - mqtt

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,14 +12,19 @@ cd zeusnet
 python -m venv .venv
 source .venv/bin/activate  # or .venv\Scripts\activate on Windows
 pip install -r backend/requirements.txt
-docker compose up -d mqtt
+docker compose up -d backend mqtt
 ```
 
 ### 🚀 Launch
 
+If you are using Docker Compose, the backend starts automatically on port
+`8000` when you ran `docker compose up`. You can also launch everything
+manually:
+
 ```bash
 bash start-zeusnet.sh  # or start-zeusnet.bat on Windows
 ```
+Set `ZEUSNET_ENV=dev` before running the script to enable hot reloads.
 
 ### 📺 GTK Desktop Viewer
 
@@ -54,3 +59,6 @@ sudo systemctl daemon-reload
 sudo systemctl enable zeusnet-serial
 sudo systemctl start zeusnet-serial
 ```
+
+This unit file expects ZeusNet under `/opt/zeusnet` with a Python virtual
+environment at `.venv` and an optional `.env` file in the same directory.

--- a/start-zeusnet.bat
+++ b/start-zeusnet.bat
@@ -4,7 +4,11 @@ cd backend
 if exist ..\.venv\Scripts\activate.bat (
     call ..\.venv\Scripts\activate.bat
 )
-start uvicorn main:app --reload
+if "%ZEUSNET_ENV%"=="dev" (
+    start uvicorn main:app --reload
+) else (
+    start uvicorn main:app --host 0.0.0.0 --port 8000
+)
 cd ..
 
 docker compose up -d mqtt

--- a/start-zeusnet.sh
+++ b/start-zeusnet.sh
@@ -7,7 +7,11 @@ cd backend
 if [ -d ../.venv ]; then
     source ../.venv/bin/activate
 fi
-uvicorn main:app --reload &
+if [ "$ZEUSNET_ENV" = "dev" ]; then
+    uvicorn main:app --reload &
+else
+    uvicorn main:app --host 0.0.0.0 --port 8000 &
+fi
 cd ..
 
 echo "Starting MQTT broker..."

--- a/systemd/zeusnet-serial.service
+++ b/systemd/zeusnet-serial.service
@@ -4,8 +4,9 @@ After=network.target
 
 [Service]
 User=zeus
-WorkingDirectory=/media/zeus/Development/GitHub/ZEUSNET
-ExecStart=/media/zeus/Development/GitHub/ZEUSNET/.venv/bin/python backend/c2/command_bus.py
+WorkingDirectory=/opt/zeusnet
+EnvironmentFile=/opt/zeusnet/.env
+ExecStart=/opt/zeusnet/.venv/bin/python backend/c2/command_bus.py
 Restart=always
 RestartSec=3
 


### PR DESCRIPTION
## Summary
- add Dockerfile for backend production use
- extend docker-compose to run backend container
- tweak launch scripts to detect `ZEUSNET_ENV` for dev reload
- document Docker usage and systemd expectations
- update service unit with generic install path

## Testing
- `black --check .` *(fails: would reformat 10 files)*
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e71dce3148324aa42f5c03ae13658