### PR TITLE
Implement attack mode selection UI

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -87,6 +87,8 @@ The window now shows a network table with filters, attack panel, a
 dashboard graph of top RSSI values and a heatmap tab. Controls let you
 change scan interval, toggle scanning, switch modes or select the serial
 port. A status bar reports the last successful update or any errors.
+The attack tab now includes a dropdown for selecting the type of attack
+before launching.
 
 ### Auto Start with systemd (Linux)
 

--- a/frontend/views/network_view.py
+++ b/frontend/views/network_view.py
@@ -11,7 +11,7 @@ from gi.repository import Gtk, GLib
 
 try:
     from ..widgets.network_list import NetworkList
-    from ..services.api_client import NetworkAPIClient
+    from backend.services.api_client import NetworkAPIClient
 except ImportError:
     import os, sys
     CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -20,7 +20,7 @@ except ImportError:
     if GRANDPARENT_DIR not in sys.path:
         sys.path.insert(0, GRANDPARENT_DIR)
     from frontend.widgets.network_list import NetworkList
-    from frontend.services.api_client import NetworkAPIClient
+    from backend.services.api_client import NetworkAPIClient
 
 logger = logging.getLogger(__name__)
 

--- a/frontend/views/settings_view.py
+++ b/frontend/views/settings_view.py
@@ -11,7 +11,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
 try:
-    from ..services.api_client import SettingsAPIClient
+    from backend.services.api_client import SettingsAPIClient
 except ImportError:  # pragma: no cover - direct execution fallback
     import os
     import sys
@@ -20,7 +20,7 @@ except ImportError:  # pragma: no cover - direct execution fallback
     GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
     if GRANDPARENT_DIR not in sys.path:
         sys.path.insert(0, GRANDPARENT_DIR)
-    from frontend.services.api_client import SettingsAPIClient
+    from backend.services.api_client import SettingsAPIClient
 
 logger = logging.getLogger(__name__)
 

--- a/frontend/widgets/network_list.py
+++ b/frontend/widgets/network_list.py
@@ -3,7 +3,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GObject, Gdk
 
 try:
-    from ..services.api_client import NetworkAPIClient
+    from backend.services.api_client import NetworkAPIClient
 except ImportError:
     import os, sys
     CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -11,7 +11,7 @@ except ImportError:
     GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
     if GRANDPARENT_DIR not in sys.path:
         sys.path.insert(0, GRANDPARENT_DIR)
-    from frontend.services.api_client import NetworkAPIClient
+    from backend.services.api_client import NetworkAPIClient
 
 class NetworkList(Gtk.ScrolledWindow):
     __gsignals__ = {


### PR DESCRIPTION
## Summary
- allow attack type selection in AttackView
- add AttackAPIClient for nic attack endpoint
- update imports to use backend services
- document attack type dropdown in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ed0b18a20832488d8a0de99255894