### PR TITLE
Fix settings validation

### DIFF
--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -1,18 +1,21 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 import os
 
 router = APIRouter()
+
 
 @router.post("/api/settings/mode")
 async def update_mode(req: Request):
     body = await req.json()
     mode = body.get("mode", "SAFE").upper()
     if mode not in ["SAFE", "AGGRESSIVE"]:
-        return {"status": "error", "message": "Invalid mode"}
+        raise HTTPException(status_code=400, detail="Invalid mode")
     os.environ["ZEUSNET_MODE"] = mode
     return {"status": "ok", "mode": mode}
 
+
 serial_port = None  # Make this global or store in app state
+
 
 @router.post("/api/settings/serial_port")
 async def set_serial_port(req: Request):
@@ -20,16 +23,20 @@ async def set_serial_port(req: Request):
     body = await req.json()
     port = body.get("port")
     if not port:
-        return {"status": "error", "message": "Missing port"}
+        raise HTTPException(status_code=400, detail="Missing port")
     serial_port = port
     return {"status": "ok", "port": port}
 
+
 watchdog_enabled = False
+
 
 @router.post("/api/settings/watchdog")
 async def toggle_watchdog(req: Request):
     global watchdog_enabled
     body = await req.json()
+    if "enabled" not in body:
+        raise HTTPException(status_code=400, detail="Missing enabled flag")
     enabled = bool(body.get("enabled", False))
     watchdog_enabled = enabled
     return {"status": "ok", "watchdog": watchdog_enabled}


### PR DESCRIPTION
## Summary
- return HTTP errors on invalid mode, serial port, or watchdog payload

## Testing
- `black backend/routes/settings.py`
- `ruff check backend/routes/settings.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0d9c981883248bae8199df9685c8