### PR TITLE
Add agents package stubs

### DIFF
--- a/backend/agents/anomaly_guard.py
+++ b/backend/agents/anomaly_guard.py
@@ -1,0 +1,25 @@
+"""AnomalyGuard agent.
+
+Runs statistical and ML checks over collected signal metrics to flag
+abnormal activity. Current implementation delegates to ``alerts.anomaly``.
+"""
+
+from sqlalchemy.orm import Session
+
+from backend.alerts.anomaly import detect_anomalies
+from backend.db import SessionLocal
+
+
+class AnomalyGuard:
+    """Analyse stored Wi-Fi scans and generate alerts."""
+
+    def __init__(self, db_session_factory=SessionLocal) -> None:
+        self.db_session_factory = db_session_factory
+
+    def scan(self) -> list[dict]:
+        """Run anomaly detection over recent scans."""
+        session: Session = self.db_session_factory()
+        try:
+            return detect_anomalies(session)
+        finally:
+            session.close()

--- a/backend/agents/command_hub.py
+++ b/backend/agents/command_hub.py
@@ -1,0 +1,15 @@
+"""CommandHub agent.
+
+Acts as the central intent router for ZeusNet. This stub exposes a simple
+``dispatch`` method used by the REST API layer.
+"""
+
+from backend.c2.command_bus import command_bus
+
+
+class CommandHub:
+    """Route commands to the SerialCommandBus."""
+
+    def dispatch(self, opcode: int, payload: dict | None = None) -> None:
+        """Forward a command to the ESP32 bus."""
+        command_bus.send(opcode, payload)

--- a/backend/agents/map_intel.py
+++ b/backend/agents/map_intel.py
@@ -1,0 +1,21 @@
+"""MapIntelligence agent.
+
+Generates map overlays from processed signal events. This is currently a
+placeholder that exposes the expected interface only.
+"""
+
+
+class MapIntelligence:
+    """Produce GeoJSON heat-map chunks for the UI."""
+
+    def __init__(self) -> None:
+        pass
+
+    def process_event(self, data: dict) -> None:
+        """Handle a processed signal event (stub)."""
+        # TODO: translate events into GeoJSON
+        pass
+
+    def start(self) -> None:
+        """Start background processing (stub)."""
+        pass

--- a/backend/agents/signal_watcher.py
+++ b/backend/agents/signal_watcher.py
@@ -1,0 +1,23 @@
+"""SignalWatcher agent.
+
+Processes Wi-Fi scan rows coming from the ESP32 and persists them to the
+database. This implementation reuses helpers from ``c2.command_bus``.
+"""
+
+from backend.c2.command_bus import SerialCommandBus, store_scan_to_db
+
+
+class SignalWatcher:
+    """Filter and store incoming signal data."""
+
+    def __init__(self, bus: SerialCommandBus | None = None) -> None:
+        self.bus = bus or SerialCommandBus()
+        self.bus.register_listener(self.handle)
+
+    def handle(self, data: dict) -> None:
+        """Persist relevant scan data to the database."""
+        store_scan_to_db(data)
+
+    def start(self) -> None:
+        """Start listening on the serial bus."""
+        self.bus.start()

--- a/backend/agents/zeus_relay.py
+++ b/backend/agents/zeus_relay.py
@@ -1,0 +1,20 @@
+"""ZeusRelay agent.
+
+Bridges serial frames from ESP32 nodes to the MQTT broker and vice versa.
+This is a thin wrapper around the existing command bus utilities.
+"""
+
+from backend.c2.command_bus import SerialCommandBus, MQTTCommandRelay
+
+
+class ZeusRelay:
+    """Bidirectional MQTT <-> Serial relay."""
+
+    def __init__(self, bus: SerialCommandBus | None = None) -> None:
+        self.bus = bus or SerialCommandBus()
+        self.relay = MQTTCommandRelay(self.bus)
+
+    def start(self) -> None:
+        """Start the underlying command bus and MQTT relay."""
+        self.bus.start()
+        self.relay.start()


### PR DESCRIPTION
## Summary
- create a new `backend/agents` package
- add stub modules for ZeusRelay, SignalWatcher, MapIntelligence, AnomalyGuard and CommandHub

## Testing
- `black --check backend/agents/zeus_relay.py backend/agents/signal_watcher.py backend/agents/map_intel.py backend/agents/anomaly_guard.py backend/agents/command_hub.py`
- `ruff check backend/agents/zeus_relay.py backend/agents/signal_watcher.py backend/agents/map_intel.py backend/agents/anomaly_guard.py backend/agents/command_hub.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686f0d77a0608324b790f9f0c25d0633