### PR TITLE
Implement mode-aware UI with new attack types

### DIFF
--- a/backend/api/nic.py
+++ b/backend/api/nic.py
@@ -28,6 +28,10 @@ class AttackService:
             return ["echo", "rogue_ap"]
         if mode == "pmkid":
             return ["echo", "pmkid"]
+        if mode == "probe":
+            return ["python3", "scripts/probe_flood.py", "--target", target or "00:00:00:00:00:00", "--iface", "wlan0"]
+        if mode == "syn_flood":
+            return ["python3", "scripts/syn_flood.py", "--target", target or "127.0.0.1", "--iface", "wlan0"]
         if mode == "swarm":
             return ["echo", "swarm"]
         if mode == "survey":

--- a/webui/package.json
+++ b/webui/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "axios": "^1.6.8"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.3",

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useSettings } from "./utils/SettingsContext";
 import Sidebar from "./components/Sidebar";
 import Topbar from "./components/Topbar";
 import SettingsDrawer from "./components/SettingsDrawer";
@@ -11,6 +12,7 @@ import AIAssistant from "./components/Tabs/AIAssistant";
 import Backups from "./components/Tabs/Backups";
 
 export default function App() {
+  const { settings } = useSettings();
   const [activeTab, setActiveTab] = useState("NetworkRecon");
   const [showSettings, setShowSettings] = useState(false);
   const [logLines, setLogLines] = useState([]);

--- a/webui/src/components/AttackForm.jsx
+++ b/webui/src/components/AttackForm.jsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { sendAttack } from "../utils/api";
+import { useSettings } from "../utils/SettingsContext";
 
 export default function AttackForm({ log }) {
+  const { settings } = useSettings();
   const [mode, setMode] = useState("deauth");
   const [target, setTarget] = useState("");
   const [channel, setChannel] = useState(6);
@@ -22,13 +24,17 @@ export default function AttackForm({ log }) {
     }
   };
 
+  const disabled = settings.mode !== "AGGRESSIVE";
+
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} className={disabled ? "locked" : ""}>
       <label>Attack Type</label>
       <select value={mode} onChange={(e) => setMode(e.target.value)}>
         <option value="deauth">Deauth</option>
         <option value="pmkid">PMKID Capture</option>
         <option value="rogue_ap">Rogue AP</option>
+        <option value="probe">Probe Flood</option>
+        <option value="syn_flood">SYN Flood</option>
       </select>
 
       {(mode === "deauth" || mode === "rogue_ap") && (
@@ -50,7 +56,9 @@ export default function AttackForm({ log }) {
         onChange={(e) => setChannel(e.target.value)}
       />
 
-      <button disabled={loading}>{loading ? "Deploying..." : "Launch Attack"}</button>
+      <button disabled={loading || disabled}>
+        {disabled ? "Locked" : loading ? "Deploying..." : "Launch Attack"}
+      </button>
     </form>
   );
 }

--- a/webui/src/components/SettingsDrawer.jsx
+++ b/webui/src/components/SettingsDrawer.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
+import { useSettings } from "../utils/SettingsContext";
 
 export default function SettingsDrawer({ open, onClose }) {
+  const { settings, setMode } = useSettings();
   const [iface, setIface] = useState("wlan0");
-  const [mode, setMode] = useState("SAFE");
   const [retries, setRetries] = useState(3);
 
   if (!open) return null;
@@ -13,7 +14,7 @@ export default function SettingsDrawer({ open, onClose }) {
       <label>Network Interface</label>
       <input value={iface} onChange={(e) => setIface(e.target.value)} />
       <label>Mode</label>
-      <select value={mode} onChange={(e) => setMode(e.target.value)}>
+      <select value={settings.mode} onChange={(e) => setMode(e.target.value)}>
         <option value="SAFE">SAFE</option>
         <option value="AGGRESSIVE">AGGRESSIVE</option>
       </select>

--- a/webui/src/components/Topbar.jsx
+++ b/webui/src/components/Topbar.jsx
@@ -1,10 +1,15 @@
 import React from "react";
+import { useSettings } from "../utils/SettingsContext";
 
 export default function Topbar({ onSettings }) {
+  const { settings } = useSettings();
   return (
     <div className="topbar">
       <h1>ZeusNet Control Core</h1>
-      <button onClick={onSettings}>⚙️</button>
+      <div>
+        <span className="mode">{settings.mode}</span>
+        <button onClick={onSettings}>⚙️</button>
+      </div>
     </div>
   );
 }

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -2,5 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/theme.css";
+import { SettingsProvider } from "./utils/SettingsContext";
 
-ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <SettingsProvider>
+    <App />
+  </SettingsProvider>
+);

--- a/webui/src/styles/theme.css
+++ b/webui/src/styles/theme.css
@@ -48,6 +48,11 @@ button {
   align-items: center;
 }
 
+.topbar .mode {
+  margin-right: 1rem;
+  font-weight: bold;
+}
+
 .main {
   flex: 1;
   display: flex;
@@ -79,4 +84,9 @@ button {
   padding: 1rem;
   width: 250px;
   height: 100vh;
+}
+
+form.locked {
+  opacity: 0.5;
+  pointer-events: none;
 }

--- a/webui/src/utils/SettingsContext.jsx
+++ b/webui/src/utils/SettingsContext.jsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { fetchSettings, updateMode } from "./api";
+
+const SettingsContext = createContext();
+
+export function SettingsProvider({ children }) {
+  const [settings, setSettings] = useState({ mode: "SAFE" });
+  useEffect(() => {
+    fetchSettings().then((data) => {
+      setSettings(data);
+      localStorage.setItem("ZEUSNET_MODE", data.mode);
+    });
+  }, []);
+
+  const setMode = async (mode) => {
+    const data = await updateMode(mode);
+    setSettings((s) => ({ ...s, mode: data.mode }));
+  };
+
+  return (
+    <SettingsContext.Provider value={{ settings, setMode }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings() {
+  return useContext(SettingsContext);
+}

--- a/webui/src/utils/api.js
+++ b/webui/src/utils/api.js
@@ -1,14 +1,21 @@
+import apiClient from "./apiClient";
+
 export async function sendAttack({ mode, target, channel }) {
-  const res = await fetch("/api/nic/attack", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ mode, target, channel }),
+  const { data } = await apiClient.post("/nic/attack", {
+    mode,
+    target,
+    channel,
   });
+  return data;
+}
 
-  if (!res.ok) {
-    const err = await res.json();
-    throw new Error(err.detail || "Unknown error");
-  }
+export async function fetchSettings() {
+  const { data } = await apiClient.get("/settings");
+  return data;
+}
 
-  return await res.json();
+export async function updateMode(mode) {
+  const { data } = await apiClient.post("/settings", { mode });
+  localStorage.setItem("ZEUSNET_MODE", data.mode);
+  return data;
 }

--- a/webui/src/utils/apiClient.js
+++ b/webui/src/utils/apiClient.js
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+const apiClient = axios.create({
+  baseURL: "/api",
+});
+
+apiClient.interceptors.request.use((config) => {
+  const mode = localStorage.getItem("ZEUSNET_MODE") || "SAFE";
+  config.headers["ZEUSNET-MODE"] = mode;
+  return config;
+});
+
+apiClient.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    const message = err.response?.data?.detail || err.message;
+    return Promise.reject(new Error(message));
+  }
+);
+
+export default apiClient;


### PR DESCRIPTION
## Summary
- extend backend attack API to run probe and SYN flood scripts
- add Axios client with interceptors
- add Settings context provider
- show current mode in the topbar and settings drawer
- lock attack form when mode is SAFE and include new attack types
- style updates for mode indicator and locked form

## Testing
- `mosquitto_pub -t zeusnet/to_esp -m '{"opcode":1,"payload":{"scan":true}}'` *(fails: command not found)*
- `mosquitto_pub -t zeusnet/from_esp -m '{"ssid":"Test","bssid":"aa:bb","rssi":-42,"timestamp":"..."}'` *(fails: command not found)*
- `curl -X POST http://localhost:8000/api/alerts/fake --data '{"type":"TEST","msg":"simulate"}'` *(fails: couldn't connect to server)*
- `curl -X POST http://localhost:8000/api/command -d '{"opcode":1,"payload":{"scan":true}}'` *(fails: couldn't connect to server)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686f01a2a290832490361562bc77101b