### PR TITLE
Add additional API tests and enable coverage check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,13 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install black ruff pytest
+        run: pip install black ruff pytest pytest-cov
       - name: Black check
         run: black --check .
       - name: Ruff lint
         run: ruff check .
-      - name: Pytest
-        run: pytest
-      - name: Pytest coverage check (placeholder)
-        run: echo "TODO: enforce coverage thresholds"
+      - name: Test with coverage
+        run: pytest --cov=backend --cov-report=term --cov-fail-under=70
   js:
     runs-on: ubuntu-latest
     steps:
@@ -39,5 +37,5 @@ jobs:
           fi
       - name: Jest
         run: npm test --if-present
-      - name: Jest coverage check (placeholder)
-        run: echo "TODO: enforce coverage thresholds"
+      - name: Jest coverage
+        run: npm test --if-present -- --coverage

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,10 @@
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from datetime import datetime, timedelta
 
 # Import routers and settings
-from backend.api import networks, settings as settings_api
+from backend.api import networks, settings as settings_api, nic, export, scan
 from backend.db import init_db
 import backend.settings as config
 
@@ -16,6 +17,9 @@ def client():
     app = FastAPI()
     app.include_router(networks.router, prefix="/api")
     app.include_router(settings_api.router, prefix="/api")
+    app.include_router(scan.router, prefix="/api")
+    app.include_router(export.router, prefix="/api")
+    app.include_router(nic.router, prefix="/api")
     with TestClient(app) as c:
         yield c
 
@@ -53,3 +57,64 @@ def test_aggressive_mode_updates_network_fields(client):
     assert items
     item = items[0]
     assert {"bssid", "auth", "channel", "timestamp"} <= item.keys()
+
+
+def test_nic_attack_requires_aggressive_mode(client):
+    config.ZEUSNET_MODE = "SAFE"
+    resp = client.post(
+        "/api/nic/attack",
+        json={"mode": "deauth", "target": "AA:BB:CC:DD:EE:FF"},
+    )
+    assert resp.status_code == 403
+
+
+def test_nic_attack_launch_and_status(client, monkeypatch):
+    config.ZEUSNET_MODE = "AGGRESSIVE"
+
+    class DummyProc:
+        def __init__(self, pid=999):
+            self.pid = pid
+
+    monkeypatch.setattr(nic.subprocess, "Popen", lambda *a, **k: DummyProc())
+    nic.attack_service.active.clear()
+
+    resp = client.post(
+        "/api/nic/attack",
+        json={"mode": "deauth", "target": "AA:BB:CC:DD:EE:FF"},
+    )
+    assert resp.status_code == 200
+    pid = resp.json()["pid"]
+    assert pid == 999
+
+    resp = client.get("/api/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["active_attacks"] == {
+        pid: {"mode": "deauth", "target": "AA:BB:CC:DD:EE:FF", "channel": None}
+    }
+
+
+def test_export_csv(client):
+    now = datetime.utcnow()
+    scan_data = [
+        {
+            "ssid": "TestNet",
+            "bssid": "AA:BB:CC:DD:EE:FF",
+            "rssi": -20,
+            "auth": "open",
+            "channel": 1,
+            "timestamp": now.isoformat(),
+        }
+    ]
+    resp = client.post("/api/scan", json=scan_data)
+    assert resp.status_code == 200
+
+    params = {
+        "from_date": (now - timedelta(minutes=1)).isoformat(),
+        "to_date": (now + timedelta(minutes=1)).isoformat(),
+    }
+    resp = client.get("/api/export/csv", params=params)
+    assert resp.status_code == 200
+    text = resp.text
+    assert "SSID,BSSID,RSSI,Auth,Channel,Timestamp" in text
+    assert "TestNet" in text


### PR DESCRIPTION
## Summary
- add test coverage for NIC attack and CSV export endpoints
- require pytest-cov with coverage threshold in CI
- run Jest with coverage flag

## Testing
- `ruff check tests/test_api.py`
- `black tests/test_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f924e043083249438b9d67083ace8