### PR TITLE
Persist serial port settings

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -11,8 +11,9 @@ router = APIRouter()
 def get_settings():
     return {
         "mode": config.ZEUSNET_MODE,
-        "serial_port": config.SERIAL_PORT,
+        "serial_port": config.get_serial_port(),
         "serial_baud": config.SERIAL_BAUD,
+        "watchdog": config.is_watchdog_enabled(),
     }
 
 
@@ -20,6 +21,7 @@ class SettingsUpdate(BaseModel):
     mode: str | None = None
     serial_port: str | None = None
     serial_baud: int | None = None
+    watchdog: bool | None = None
 
 
 @router.post("/settings")
@@ -28,9 +30,10 @@ def update_settings(data: SettingsUpdate):
         config.ZEUSNET_MODE = data.mode
         os.environ["ZEUSNET_MODE"] = data.mode
     if data.serial_port:
-        config.SERIAL_PORT = data.serial_port
-        os.environ["SERIAL_PORT"] = data.serial_port
+        config.set_serial_port(data.serial_port)
     if data.serial_baud:
         config.SERIAL_BAUD = data.serial_baud
         os.environ["SERIAL_BAUD"] = str(data.serial_baud)
+    if data.watchdog is not None:
+        config.set_watchdog_enabled(bool(data.watchdog))
     return get_settings()

--- a/backend/c2/command_bus.py
+++ b/backend/c2/command_bus.py
@@ -18,7 +18,7 @@ from backend.db import SessionLocal
 from backend.models import WiFiScan
 
 from backend.settings import (
-    SERIAL_PORT,
+    get_serial_port,
     SERIAL_BAUD,
     MQTT_BROKER,
     MQTT_TOPIC,
@@ -104,7 +104,7 @@ class SerialCommandBus:
             self._save_last_known_port(ports[0])
             return ports[0]
 
-        return SERIAL_PORT
+        return get_serial_port()
 
     def _udev_callback(self, action, device):
         logger.info(f"[udev] {action} detected: {device.device_node}")

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,14 +1,68 @@
+import json
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# Persistent config storage (~/.config/zeusnet/settings.json)
+CONFIG_DIR = Path.home() / ".config" / "zeusnet"
+CONFIG_FILE = CONFIG_DIR / "settings.json"
+
+
+def _load_config() -> dict:
+    if CONFIG_FILE.exists():
+        try:
+            return json.loads(CONFIG_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_config(cfg: dict) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps(cfg))
+
+
+_config = _load_config()
+
+if "serial_port" not in _config:
+    _config["serial_port"] = os.getenv("SERIAL_PORT", "/dev/ttyUSB0")
+if "watchdog_enabled" not in _config:
+    _config["watchdog_enabled"] = False
+
+_save_config(_config)
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///zeusnet.db")
 ZEUSNET_MODE = os.getenv("ZEUSNET_MODE", "SAFE")
 
 # Serial and MQTT defaults for command bus
-SERIAL_PORT = os.getenv("SERIAL_PORT", "/dev/ttyUSB0")
+SERIAL_PORT = _config.get("serial_port", "/dev/ttyUSB0")
 SERIAL_BAUD = int(os.getenv("SERIAL_BAUD", "115200"))
 MQTT_BROKER = os.getenv("MQTT_BROKER", "localhost")
 MQTT_TOPIC = os.getenv("MQTT_TOPIC", "zeusnet")
 RETRY_LIMIT = int(os.getenv("RETRY_LIMIT", "3"))
+
+
+def get_serial_port() -> str:
+    """Return the persisted serial port setting."""
+    return _config.get("serial_port", SERIAL_PORT)
+
+
+def set_serial_port(port: str) -> None:
+    """Persist a new serial port value."""
+    global SERIAL_PORT
+    SERIAL_PORT = port
+    _config["serial_port"] = port
+    _save_config(_config)
+
+
+def is_watchdog_enabled() -> bool:
+    """Return whether the watchdog is enabled."""
+    return bool(_config.get("watchdog_enabled", False))
+
+
+def set_watchdog_enabled(enabled: bool) -> None:
+    """Persist the watchdog enabled state."""
+    _config["watchdog_enabled"] = bool(enabled)
+    _save_config(_config)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ def test_get_settings(client):
     resp = client.get("/api/settings")
     assert resp.status_code == 200
     data = resp.json()
-    assert {"mode", "serial_port", "serial_baud"} <= data.keys()
+    assert {"mode", "serial_port", "serial_baud", "watchdog"} <= data.keys()
 
 
 def test_get_networks_default_mode(client):


### PR DESCRIPTION
## Summary
- add persistent config file handling
- include watchdog and serial port persistence APIs
- patch command bus to read current port
- update tests for added fields

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f923f98508324886182bd3f119610