### PR TITLE
Fix duplicate WiFiScans endpoint

### DIFF
--- a/backend/routes/networks.py
+++ b/backend/routes/networks.py
@@ -5,11 +5,11 @@ from backend.models import WiFiScan
 
 router = APIRouter()
 
+
 @router.get("/WiFiScans")
 async def get_WiFiScans(limit: int = 50, db: Session = Depends(get_db)):
-    # Query for most recent N WiFiScans; customize for your schema
+    """Return the most recent WiFiScan rows as plain dictionaries."""
     rows = db.query(WiFiScan).order_by(WiFiScan.id.desc()).limit(limit).all()
-    # Convert ORM rows to plain dicts
     return [
         {
             "id": n.id,
@@ -19,14 +19,3 @@ async def get_WiFiScans(limit: int = 50, db: Session = Depends(get_db)):
         }
         for n in rows
     ]
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-from backend.db import get_db
-from backend.models import WiFiScan
-
-router = APIRouter()
-
-@router.get("/WiFiScans")
-async def get_WiFiScans(limit: int = 50, db: Session = Depends(get_db)):
-    scans = db.query(WiFiScan).order_by(WiFiScan.id.desc()).limit(limit).all()
-    return [s.to_dict() for s in scans]


### PR DESCRIPTION
## Summary
- clean up `backend/routes/networks.py`

## Testing
- `black --check backend/routes/networks.py`
- `ruff check backend/routes/networks.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f92141d0483248d4e04c6bba8d502