### PR TITLE
Add httpx to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ uvicorn[standard]==0.29.0
 pydantic==2.6.4
 sqlalchemy==2.0.30
 paho-mqtt==2.1.0
+httpx==0.27.0
 # --- Networking & Pentesting Tools ---
 scapy==2.5.0
 pyserial==3.5


### PR DESCRIPTION
## Summary
- ensure FastAPI TestClient has httpx by adding the dependency under the core framework group

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f91f3e34083248e9c912dadedb29a