### PR TITLE
refactor(frontend): remove sys.path hacks

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,7 +32,7 @@ Launch the desktop UI with tabs for network lists, signal charts,
 map view and attack controls:
 
 ```bash
-python frontend/main.py
+python -m frontend.main
 ```
 
 Requires the `PyGObject` package with GTK **4** support.

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,25 +1,15 @@
 """GTK application setup for ZeusNet."""
 
 import gi
+
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk
 
-try:
-    from .views.network_view import NetworkView
-    from .views.attack_view import AttackView
-    from .views.settings_view import SettingsView
-    from .views.dashboard_view import DashboardView
-except ImportError:
-    import os
-    import sys
-    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-    PARENT_DIR = os.path.dirname(CURRENT_DIR)
-    if PARENT_DIR not in sys.path:
-        sys.path.insert(0, PARENT_DIR)
-    from frontend.views.network_view import NetworkView
-    from frontend.views.attack_view import AttackView
-    from frontend.views.settings_view import SettingsView
-    from frontend.views.dashboard_view import DashboardView
+from .views.network_view import NetworkView
+from .views.attack_view import AttackView
+from .views.settings_view import SettingsView
+from .views.dashboard_view import DashboardView
+
 
 class ZeusApp(Gtk.Application):
     """Main GTK application class."""
@@ -32,6 +22,7 @@ class ZeusApp(Gtk.Application):
         if not hasattr(self, "window") or self.window is None:
             self.window = ZeusAppWindow(application=self)
         self.window.present()
+
 
 class ZeusAppWindow(Gtk.ApplicationWindow):
     """Main Application Window with tab control and attack glue."""

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -21,16 +21,10 @@ if os.path.exists(CSS_PATH):
         Gtk.STYLE_PROVIDER_PRIORITY_USER,
     )
 
+
 def main() -> int:
-    try:
-        from frontend.app import ZeusApp
-        from frontend.utils.logging import configure_logging
-    except ImportError:
-        PARENT_DIR = os.path.dirname(CURRENT_DIR)
-        if PARENT_DIR not in sys.path:
-            sys.path.insert(0, PARENT_DIR)
-        from frontend.app import ZeusApp
-        from frontend.utils.logging import configure_logging
+    from frontend.app import ZeusApp
+    from frontend.utils.logging import configure_logging
 
     print("Launching ZeusNet GTK Frontend...")
     configure_logging()
@@ -38,6 +32,7 @@ def main() -> int:
     rc = app.run()
     print("ZeusNet exited with code:", rc)
     return rc
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/frontend/views/attack_view.py
+++ b/frontend/views/attack_view.py
@@ -3,19 +3,12 @@
 """Attack tab with prefillable target controls."""
 
 import gi
+
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GObject
 
-try:
-    from backend.services.api_client import AttackAPIClient
-except ImportError:
-    import os, sys
-    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-    PARENT_DIR = os.path.dirname(CURRENT_DIR)
-    GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
-    if GRANDPARENT_DIR not in sys.path:
-        sys.path.insert(0, GRANDPARENT_DIR)
-    from backend.services.api_client import AttackAPIClient
+from backend.services.api_client import AttackAPIClient
+
 
 class AttackView(Gtk.Box):
     """
@@ -121,13 +114,15 @@ class AttackView(Gtk.Box):
 
     def prefill_target(self, net_info):
         """Prefill all target fields from provided network info."""
-        self.ssid_entry.set_text(net_info.get('ssid', ''))
-        self.bssid_entry.set_text(net_info.get('bssid', ''))
-        self.channel_entry.set_text(str(net_info.get('channel', '')))
-        self.enc_entry.set_text(net_info.get('encryption', ''))
-        self.quality_entry.set_text(str(net_info.get('quality', '')))
-        self.rssi_entry.set_text(str(net_info.get('rssi', '')))
-        self.status_label.set_text("Target loaded. Ready to launch your diabolical plan.")
+        self.ssid_entry.set_text(net_info.get("ssid", ""))
+        self.bssid_entry.set_text(net_info.get("bssid", ""))
+        self.channel_entry.set_text(str(net_info.get("channel", "")))
+        self.enc_entry.set_text(net_info.get("encryption", ""))
+        self.quality_entry.set_text(str(net_info.get("quality", "")))
+        self.rssi_entry.set_text(str(net_info.get("rssi", "")))
+        self.status_label.set_text(
+            "Target loaded. Ready to launch your diabolical plan."
+        )
 
     def on_attack_clicked(self, _btn):
         """Launch selected attack via backend API."""
@@ -154,4 +149,3 @@ class AttackView(Gtk.Box):
             on_success=_on_success,
             on_error=_on_error,
         )
-

--- a/frontend/views/network_view.py
+++ b/frontend/views/network_view.py
@@ -9,26 +9,18 @@ from typing import Dict
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
-try:
-    from ..widgets.network_list import NetworkList
-    from backend.services.api_client import NetworkAPIClient
-except ImportError:
-    import os, sys
-    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-    PARENT_DIR = os.path.dirname(CURRENT_DIR)
-    GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
-    if GRANDPARENT_DIR not in sys.path:
-        sys.path.insert(0, GRANDPARENT_DIR)
-    from frontend.widgets.network_list import NetworkList
-    from backend.services.api_client import NetworkAPIClient
+from ..widgets.network_list import NetworkList
+from backend.services.api_client import NetworkAPIClient
 
 logger = logging.getLogger(__name__)
+
 
 class NetworkView(Gtk.Box):
     """
     Displays available networks with filter controls and double-click-to-attack UX.
     Emits target info to main window/controller for prefilled attack tab.
     """
+
     def __init__(self, parent_controller=None) -> None:
         """
         Args:
@@ -92,19 +84,21 @@ class NetworkView(Gtk.Box):
             self.status_label.set_text("Failed to load networks")
 
         self.api_client.get_networks_async(
-            filters=filters,
-            on_success=_on_success,
-            on_error=_on_error
+            filters=filters, on_success=_on_success, on_error=_on_error
         )
 
     def on_target_selected(self, widget, net_info):
         logger.info(f"Target selected: {net_info}")
         # Use parent_controller if present, else root
-        if self.parent_controller and hasattr(self.parent_controller, "switch_to_attack_tab"):
+        if self.parent_controller and hasattr(
+            self.parent_controller, "switch_to_attack_tab"
+        ):
             self.parent_controller.switch_to_attack_tab(net_info)
         else:
             root = self.get_root()
             if root and hasattr(root, "switch_to_attack_tab"):
                 root.switch_to_attack_tab(net_info)
             else:
-                logger.warning("No attack tab handler found for double-click target event.")
+                logger.warning(
+                    "No attack tab handler found for double-click target event."
+                )

--- a/frontend/views/settings_view.py
+++ b/frontend/views/settings_view.py
@@ -10,19 +10,10 @@ from serial.tools import list_ports
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib
 
-try:
-    from backend.services.api_client import SettingsAPIClient
-except ImportError:  # pragma: no cover - direct execution fallback
-    import os
-    import sys
-    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-    PARENT_DIR = os.path.dirname(CURRENT_DIR)
-    GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
-    if GRANDPARENT_DIR not in sys.path:
-        sys.path.insert(0, GRANDPARENT_DIR)
-    from backend.services.api_client import SettingsAPIClient
+from backend.services.api_client import SettingsAPIClient
 
 logger = logging.getLogger(__name__)
+
 
 class SettingsView(Gtk.Box):
     """Settings tab for controlling mode, serial port, and watchdog."""

--- a/frontend/widgets/network_list.py
+++ b/frontend/widgets/network_list.py
@@ -1,17 +1,10 @@
 import gi
+
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GObject, Gdk
 
-try:
-    from backend.services.api_client import NetworkAPIClient
-except ImportError:
-    import os, sys
-    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-    PARENT_DIR = os.path.dirname(CURRENT_DIR)
-    GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
-    if GRANDPARENT_DIR not in sys.path:
-        sys.path.insert(0, GRANDPARENT_DIR)
-    from backend.services.api_client import NetworkAPIClient
+from backend.services.api_client import NetworkAPIClient
+
 
 class NetworkList(Gtk.ScrolledWindow):
     __gsignals__ = {
@@ -74,12 +67,15 @@ class NetworkList(Gtk.ScrolledWindow):
 
     def load_networks(self, filters: dict) -> None:
         self.set_loading_state(True)
+
         def _on_success(networks):
             self.set_loading_state(False)
             self.load_data(networks)
+
         def _on_error(err):
             self.set_loading_state(False)
             self.table_box.append(Gtk.Label(label=f"Failed to load networks: {err}"))
+
         self.api_client.get_networks_async(filters, _on_success, _on_error)
 
     def load_data(self, networks):
@@ -89,13 +85,15 @@ class NetworkList(Gtk.ScrolledWindow):
             return
 
         try:
-            networks = sorted(networks, key=lambda n: int(n.get("rssi", -999)), reverse=True)
+            networks = sorted(
+                networks, key=lambda n: int(n.get("rssi", -999)), reverse=True
+            )
         except Exception:
             pass
 
         seen = set()
         for n in networks:
-            key = (n.get('ssid'), n.get('bssid'), n.get('channel'))
+            key = (n.get("ssid"), n.get("bssid"), n.get("channel"))
             if key in seen:
                 continue
             seen.add(key)
@@ -111,7 +109,7 @@ class NetworkList(Gtk.ScrolledWindow):
                 Gtk.Label(label=f"{n.get('bssid','—')}", xalign=0),
                 Gtk.Label(label=f"{n.get('channel','—')}", xalign=0),
                 Gtk.Label(label=f"{n.get('encryption','—')}", xalign=0),
-                Gtk.Label(label=f"{n.get('quality','—')}", xalign=0)
+                Gtk.Label(label=f"{n.get('quality','—')}", xalign=0),
             ]
             for idx, widget in enumerate(widgets):
                 widget.set_margin_start(12)

--- a/gtk_launcher.py
+++ b/gtk_launcher.py
@@ -3,4 +3,4 @@
 import sys
 import os
 
-os.execv(sys.executable, ["python3", "frontend/main.py"])
+os.execv(sys.executable, ["python3", "-m", "frontend.main"])

--- a/start-zeusnet.bat
+++ b/start-zeusnet.bat
@@ -13,5 +13,5 @@ cd ..
 
 docker compose up -d mqtt
 
-python frontend/main.py
+python -m frontend.main
 

--- a/start-zeusnet.sh
+++ b/start-zeusnet.sh
@@ -21,7 +21,7 @@ echo "Starting MQTT broker..."
 docker compose up -d mqtt
 
 echo "Starting ZeusNet Frontend..."
-python3 frontend/main.py > frontend.log 2>&1 &
+python3 -m frontend.main > frontend.log 2>&1 &
 FRONTEND_PID=$!
 
 # Graceful shutdown trap (optional)


### PR DESCRIPTION
## Summary
- make frontend modules use package imports
- call frontend via `python -m frontend.main`
- update docs and launch scripts for new invocation

## Testing
- `black --check frontend/app.py frontend/main.py frontend/views/attack_view.py frontend/views/network_view.py frontend/views/settings_view.py frontend/widgets/network_list.py gtk_launcher.py`
- `ruff check frontend/app.py frontend/main.py frontend/views/attack_view.py frontend/views/network_view.py frontend/views/settings_view.py frontend/widgets/network_list.py gtk_launcher.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `python -m frontend.main` *(fails: No module named 'gi')*

------
https://chatgpt.com/codex/tasks/task_e_686f91c6839c8324bb7cb5152f168380