### PR TITLE
Add GeoJSON support to MapIntelligence

### DIFF
--- a/backend/agents/map_intel.py
+++ b/backend/agents/map_intel.py
@@ -5,16 +5,51 @@ placeholder that exposes the expected interface only.
 """
 
 
+from collections import deque
+from typing import Deque
+
+
 class MapIntelligence:
     """Produce GeoJSON heat-map chunks for the UI."""
 
-    def __init__(self) -> None:
-        pass
+    def __init__(self, history_size: int = 100) -> None:
+        self.history_size = history_size
+        self._recent: Deque[dict] = deque(maxlen=history_size)
 
-    def process_event(self, data: dict) -> None:
-        """Handle a processed signal event (stub)."""
-        # TODO: translate events into GeoJSON
-        pass
+    def process_event(self, data: dict) -> dict:
+        """Translate a signal event into a GeoJSON Feature.
+
+        Parameters
+        ----------
+        data: dict
+            Event data containing ``lat`` and ``lon`` keys either at the top
+            level or under ``payload``.
+
+        Returns
+        -------
+        dict
+            GeoJSON Feature representing the event.
+        """
+
+        payload = data.get("payload", data)
+        lat = payload.get("lat")
+        lon = payload.get("lon")
+        if lat is None or lon is None:
+            raise ValueError("Event must include 'lat' and 'lon' coordinates")
+
+        properties = {k: v for k, v in payload.items() if k not in {"lat", "lon"}}
+        feature = {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [lon, lat]},
+            "properties": properties,
+        }
+        self._recent.append(feature)
+        return feature
+
+    def get_recent_features(self) -> list[dict]:
+        """Return the most recently processed GeoJSON features."""
+
+        return list(self._recent)
 
     def start(self) -> None:
         """Start background processing (stub)."""

--- a/tests/test_map_intel.py
+++ b/tests/test_map_intel.py
@@ -1,0 +1,30 @@
+import pytest
+from backend.agents.map_intel import MapIntelligence
+
+
+def test_process_event_to_geojson():
+    agent = MapIntelligence(history_size=5)
+    event = {"payload": {"ssid": "net", "rssi": -45, "lat": 1.0, "lon": 2.0}}
+    feature = agent.process_event(event)
+    assert feature["type"] == "Feature"
+    assert feature["geometry"] == {"type": "Point", "coordinates": [2.0, 1.0]}
+    assert feature["properties"]["ssid"] == "net"
+    assert agent.get_recent_features() == [feature]
+
+
+def test_history_rollover():
+    agent = MapIntelligence(history_size=2)
+    agent.process_event({"payload": {"lat": 0, "lon": 0}})
+    second = agent.process_event({"payload": {"lat": 1, "lon": 1}})
+    third = agent.process_event({"payload": {"lat": 2, "lon": 2}})
+
+    recent = agent.get_recent_features()
+    assert len(recent) == 2
+    assert recent[0] == second
+    assert recent[1] == third
+
+
+def test_missing_coords_raises():
+    agent = MapIntelligence()
+    with pytest.raises(ValueError):
+        agent.process_event({"payload": {"lat": 0}})


### PR DESCRIPTION
## Summary
- implement GeoJSON feature creation in `MapIntelligence`
- track recent map features and expose accessor
- add unit tests for MapIntelligence behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*
- `pip install -q -r requirements.txt` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686f91ab3960832482463104d8603a2f