### PR TITLE
Add logging setup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,11 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
+import logging
+
+from backend.utils.logging import configure_logging
+
+logger = logging.getLogger(__name__)
 
 # 🧠 Load env vars (e.g., ZEUSNET_MODE)
 load_dotenv()
@@ -77,5 +82,7 @@ app.include_router(route_nic.router)
 # Startup: DB and C2 bus
 @app.on_event("startup")
 def _startup():
+    configure_logging()
+    logger.info("Starting backend services")
     init_db()
     start_bus()

--- a/backend/utils/logging.py
+++ b/backend/utils/logging.py
@@ -1,0 +1,10 @@
+"""Logging utilities for the ZeusNet backend."""
+
+import logging
+
+
+def configure_logging(level: int = logging.INFO,
+                      fmt: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s") -> None:
+    """Configure the root logger."""
+    logging.basicConfig(level=level, format=fmt)
+

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import logging
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -32,11 +33,12 @@ def main() -> int:
         from frontend.app import ZeusApp
         from frontend.utils.logging import configure_logging
 
-    print("Launching ZeusNet GTK Frontend...")
     configure_logging()
+    logger = logging.getLogger(__name__)
+    logger.info("Launching ZeusNet GTK Frontend...")
     app = ZeusApp()
     rc = app.run()
-    print("ZeusNet exited with code:", rc)
+    logger.info("ZeusNet exited with code: %s", rc)
     return rc
 
 if __name__ == "__main__":

--- a/frontend/utils/logging.py
+++ b/frontend/utils/logging.py
@@ -3,16 +3,19 @@
 import logging
 
 
-def configure_logging(level: int = logging.INFO) -> None:
+def configure_logging(
+    level: int = logging.INFO,
+    fmt: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+) -> None:
     """Configure the root logger.
 
     Parameters
     ----------
     level : int
         Logging level for root logger. Defaults to ``logging.INFO``.
+    fmt : str
+        Log message format.
     """
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
+    logging.basicConfig(level=level, format=fmt)
+
 


### PR DESCRIPTION
## Summary
- configure backend logging utilities
- enhance frontend logging utilities
- log frontend startup/shutdown instead of print
- configure backend logging during startup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f9266b5ec83248e496516140b75f7