### PR TITLE
Fix import order and remove unused modules

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,9 +2,6 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 
-# 🧠 Load env vars (e.g., ZEUSNET_MODE)
-load_dotenv()
-
 # 🧠 Real ZeusNet routers
 from backend.api import (
     scan,
@@ -25,6 +22,9 @@ from backend.routes import nic as route_nic
 
 from backend.c2.command_bus import start_bus
 from backend.db import init_db
+
+# 🧠 Load env vars (e.g., ZEUSNET_MODE)
+load_dotenv()
 
 # 🚀 FastAPI app
 app = FastAPI(

--- a/backend/routes/networks.py
+++ b/backend/routes/networks.py
@@ -1,32 +1,14 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+
 from backend.db import get_db
 from backend.models import WiFiScan
 
 router = APIRouter()
 
-@router.get("/WiFiScans")
-async def get_WiFiScans(limit: int = 50, db: Session = Depends(get_db)):
-    # Query for most recent N WiFiScans; customize for your schema
-    rows = db.query(WiFiScan).order_by(WiFiScan.id.desc()).limit(limit).all()
-    # Convert ORM rows to plain dicts
-    return [
-        {
-            "id": n.id,
-            "ssid": n.ssid,
-            "rssi": n.rssi,
-            # Add more fields as needed: "bssid": n.bssid, etc.
-        }
-        for n in rows
-    ]
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-from backend.db import get_db
-from backend.models import WiFiScan
-
-router = APIRouter()
 
 @router.get("/WiFiScans")
 async def get_WiFiScans(limit: int = 50, db: Session = Depends(get_db)):
+    """Return the most recent WiFi scans."""
     scans = db.query(WiFiScan).order_by(WiFiScan.id.desc()).limit(limit).all()
     return [s.to_dict() for s in scans]

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -2,7 +2,7 @@
 
 import gi
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk
+from gi.repository import Gtk  # noqa: E402
 
 try:
     from .views.network_view import NetworkView

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -6,7 +6,7 @@ import sys
 import gi
 
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk, Gdk  # Gdk needed for CSS
+from gi.repository import Gtk, Gdk  # noqa: E402  # Gdk needed for CSS
 
 # --- CSS LOADER: Load custom style before any windows ---
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/frontend/views/attack_view.py
+++ b/frontend/views/attack_view.py
@@ -4,12 +4,13 @@
 
 import gi
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk, GObject
+from gi.repository import Gtk  # noqa: E402
 
 try:
     from backend.services.api_client import AttackAPIClient
 except ImportError:
-    import os, sys
+    import os
+    import sys
     CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
     PARENT_DIR = os.path.dirname(CURRENT_DIR)
     GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)

--- a/frontend/views/network_view.py
+++ b/frontend/views/network_view.py
@@ -7,13 +7,14 @@ import logging
 from typing import Dict
 
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk, GLib  # noqa: E402
 
 try:
     from ..widgets.network_list import NetworkList
     from backend.services.api_client import NetworkAPIClient
 except ImportError:
-    import os, sys
+    import os
+    import sys
     CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
     PARENT_DIR = os.path.dirname(CURRENT_DIR)
     GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)

--- a/frontend/views/settings_view.py
+++ b/frontend/views/settings_view.py
@@ -4,11 +4,10 @@
 
 import gi
 import logging
-from typing import Optional
 from serial.tools import list_ports
 
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk, GLib  # noqa: E402
 
 try:
     from backend.services.api_client import SettingsAPIClient

--- a/frontend/widgets/network_list.py
+++ b/frontend/widgets/network_list.py
@@ -1,11 +1,12 @@
 import gi
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import Gtk, GObject  # noqa: E402
 
 try:
     from backend.services.api_client import NetworkAPIClient
 except ImportError:
-    import os, sys
+    import os
+    import sys
     CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
     PARENT_DIR = os.path.dirname(CURRENT_DIR)
     GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)

--- a/frontend/widgets/status_bar.py
+++ b/frontend/widgets/status_bar.py
@@ -3,7 +3,7 @@
 import gi
 gi.require_version("Gtk", "4.0")
 
-from gi.repository import Gtk
+from gi.repository import Gtk  # noqa: E402
 
 
 class StatusBar(Gtk.Statusbar):

--- a/scripts/probe_flood.py
+++ b/scripts/probe_flood.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import sys
 import time
 import random
 import argparse

--- a/scripts/syn_flood.py
+++ b/scripts/syn_flood.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import sys
-import time
 import random
 import argparse
 from scapy.all import IP, TCP, send


### PR DESCRIPTION
## Summary
- reorder imports so they're all at the top of each file
- remove unused imports from GTK views and attack scripts
- split try/except imports
- clean up networking routes module

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f929b29808324b3645c7387b962f0