### PR TITLE
Mark MapIntelligence as planned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 |-----------------|-------------|-----------------------------------------------------------------------------------------------|----------------------------------------------|
 | ZeusRelay       | MQTT Agent  | Bridges MQTT ⇆ Serial traffic for remote command & control, status heartbeat propagation      | `backend/agents/zeus_relay.py`               |
 | SignalWatcher   | Sensor AI   | Listens to ESP32 RSSI / SSID data, de-noises, timestamps and streams into the DB              | `backend/agents/signal_watcher.py`           |
-| MapIntelligence | Visual AI   | Converts live network events into geo-referenced overlays for the UI heat-map                 | `backend/agents/map_intel.py`                |
+| MapIntelligence | Visual AI   | ⚙️ Planned - convert events to heat-map overlays                 | `backend/agents/map_intel.py`               |
 | AnomalyGuard    | Defense AI  | Performs statistical / ML anomaly detection on signal metrics                                 | `backend/agents/anomaly_guard.py`            |
 | CommandHub      | Core Agent  | Central intent router: interprets user inputs & dispatches tasks to other agents              | `backend/agents/command_hub.py`              |
 
@@ -138,14 +138,14 @@ mosquitto_pub -t zeusnet/from_esp -m '{"ssid":"Test","bssid":"aa:bb","rssi":-42,
 
 **Type**: `Synthesizer`
 **ID**: `agent_mapintel`
-**Status**: 🟢 Active
-**Version**: `v1.0.0`
+**Status**: ⚙️ Planned
+**Version**: `v0.1.0`
 **Scope**: `Hybrid`
-**Visibility**: `User-facing`
+**Visibility**: `Experimental`
 
 ### 🎯 Purpose
 
-Transforms processed signal events into GeoJSON heat-layers for the React or GTK front-end, enabling a real-time map overlay.
+Transforms processed signal events into GeoJSON heat-layers for the React or GTK front-end, enabling a real-time map overlay. *(Not yet implemented)*
 
 ### 🔧 Capabilities
 
@@ -273,6 +273,7 @@ curl -X POST http://localhost:8000/api/command -d '{"opcode":1,"payload":{"scan"
 | ReconBot      | Recon Agent  | ⚙️ Planned | Actively sweeps all channels & logs new BSSIDs   |
 | IntelBroker   | Meta Agent   | ⚙️ Planned | Aggregates intel from multiple ZeusNet instances |
 | ZeusCommander | Master Agent | ⚙️ Planned | Multi-node orchestration & advanced task graph   |
+| MapIntelligence | Visual AI   | ⚙️ Planned | Creates GeoJSON overlays for the heatmap dashboard |
 
 ---
 

--- a/README.MD
+++ b/README.MD
@@ -16,7 +16,7 @@
 | 📊 Export to CSV/Excel       | Export tables directly from the GTK UI             |
 | 🔥 Deauth & AP cloning       | Enabled via TL‑WN722N NIC in aggressive mode     |
 | 🧪 TL‑WN722N automation      | Controlled packet injection, handshake captures  |
-| 🗺️ Heatmap dashboard         | Leaflet-powered map view in GTK UI |
+| 🗺️ Heatmap dashboard         | Leaflet-powered map view in GTK UI *(coming soon)* |
 | 🎛️ In-app pentest controls  | Toggle mode and launch attacks via UI |
 | 📜 Advanced network list     | Filter scans by SSID or auth mode |
 | 📈 Signal charts             | Top RSSI graph in Dashboard tab |
@@ -83,10 +83,12 @@ python -m frontend.main
 
 This requires the `PyGObject` package built with GTK **4**.
 
-The window now shows a network table with filters, attack panel, a
-dashboard graph of top RSSI values and a heatmap tab. Controls let you
-change scan interval, toggle scanning, switch modes or select the serial
-port. A status bar reports the last successful update or any errors.
+The window now shows a network table with filters, attack panel and a
+dashboard graph of top RSSI values. A heatmap tab is present but will
+remain empty until the MapIntelligence agent is implemented. Controls let
+you change scan interval, toggle scanning, switch modes or select the
+serial port. A status bar reports the last successful update or any
+errors.
 The attack tab now includes a dropdown for selecting the type of attack
 before launching.
 

--- a/backend/agents/map_intel.py
+++ b/backend/agents/map_intel.py
@@ -1,7 +1,8 @@
 """MapIntelligence agent.
 
-Generates map overlays from processed signal events. This is currently a
-placeholder that exposes the expected interface only.
+This experimental module will eventually generate map overlays from
+processed signal events. It currently exists as a placeholder and is not
+used in production.
 """
 
 
@@ -9,13 +10,14 @@ class MapIntelligence:
     """Produce GeoJSON heat-map chunks for the UI."""
 
     def __init__(self) -> None:
+        """Initialize the agent (no-op while experimental)."""
         pass
 
     def process_event(self, data: dict) -> None:
-        """Handle a processed signal event (stub)."""
-        # TODO: translate events into GeoJSON
+        """Handle a processed signal event (currently a stub)."""
+        # Future: translate events into GeoJSON
         pass
 
     def start(self) -> None:
-        """Start background processing (stub)."""
+        """Start background processing (currently a stub)."""
         pass

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -29,7 +29,7 @@ Set `ZEUSNET_ENV=dev` before running the script to enable hot reloads.
 ### 📺 GTK Desktop Viewer
 
 Launch the desktop UI with tabs for network lists, signal charts,
-map view and attack controls:
+an experimental map view and attack controls:
 
 ```bash
 python frontend/main.py
@@ -39,7 +39,8 @@ Requires the `PyGObject` package with GTK **4** support.
 If you encounter an error about `Gtk.ApplicationFlags` when launching the
 UI, ensure you are not using leftover GTK 3 snippets; the new code relies
 solely on GTK 4 APIs. The `Application.run()` method also no longer takes a
-`None` parameter in GTK 4.
+`None` parameter in GTK 4. The map view will remain blank until the
+MapIntelligence agent is available.
 
 ### 🌐 Web UI (React)
 


### PR DESCRIPTION
## Summary
- mark MapIntelligence agent as planned/experimental in `AGENTS.md`
- mention upcoming heatmap feature in README and setup docs
- clarify that `map_intel.py` is experimental

## Testing
- `ruff check backend/agents/map_intel.py`
- `black --check backend/agents/map_intel.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f927346e48324adbfcbe97be0add9