### PR TITLE
Add GTK views and API endpoints for PacketForge and AI Assistant

### DIFF
--- a/backend/api/assistant.py
+++ b/backend/api/assistant.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class ChatRequest(BaseModel):
+    prompt: str
+
+
+@router.post("/assistant/chat")
+def assistant_chat(req: ChatRequest) -> dict:
+    """Trivial echo-style AI assistant for demo purposes."""
+    return {"response": req.prompt[::-1]}

--- a/backend/api/forge.py
+++ b/backend/api/forge.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class ForgePacket(BaseModel):
+    frame_type: str
+    payload: str
+
+
+@router.post("/forge/send")
+def forge_send(packet: ForgePacket) -> dict:
+    """Accept a crafted packet and echo a simple status."""
+    return {
+        "status": "sent",
+        "frame_type": packet.frame_type,
+        "length": len(packet.payload),
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,8 @@ from backend.api import (
     diagnostic,
     covert_ops_agent,
     aireplay,
+    forge,
+    assistant,
 )
 from backend.routes import networks as route_networks
 from backend.routes import settings as route_settings
@@ -54,6 +56,8 @@ def read_root():
         "command": "/api/command",
         "export_csv": "/api/export/csv",
         "mode": "/api/settings/mode",
+        "forge": "/api/forge/send",
+        "assistant": "/api/assistant/chat",
     }
 
 # API Routers (always /api prefix)
@@ -68,6 +72,8 @@ app.include_router(nic.router, prefix="/api")
 app.include_router(diagnostic.router, prefix="/api")
 app.include_router(covert_ops_agent.router, prefix="/api")
 app.include_router(aireplay.router, prefix="/api")
+app.include_router(forge.router, prefix="/api")
+app.include_router(assistant.router, prefix="/api")
 
 # Custom SQLAlchemy routes (for legacy/extra DB stuff)
 app.include_router(route_networks.router, prefix="/api")

--- a/backend/services/api_client.py
+++ b/backend/services/api_client.py
@@ -138,3 +138,72 @@ class AttackAPIClient:
                 GLib.idle_add(on_error, exc)
 
         threading.Thread(target=_task, daemon=True).start()
+
+
+# === Packet Forge CLIENT ===
+
+class ForgeAPIClient:
+    """Client for custom packet crafting endpoints."""
+
+    def __init__(self, base_url: str = "http://localhost:8000/api"):
+        self.base_url = base_url.rstrip("/")
+
+    def send_packet(self, frame_type: str, payload: str) -> Dict[str, Any]:
+        resp = requests.post(
+            f"{self.base_url}/forge/send",
+            json={"frame_type": frame_type, "payload": payload},
+            timeout=6,
+        )
+        if resp.status_code != 200:
+            raise APIError(f"HTTP {resp.status_code}: {resp.text}")
+        return resp.json()
+
+    def send_packet_async(
+        self,
+        frame_type: str,
+        payload: str,
+        on_success: Callable[[Dict[str, Any]], None],
+        on_error: Callable[[Exception], None],
+    ) -> None:
+        def _task():
+            try:
+                data = self.send_packet(frame_type, payload)
+                GLib.idle_add(on_success, data)
+            except Exception as exc:
+                GLib.idle_add(on_error, exc)
+
+        threading.Thread(target=_task, daemon=True).start()
+
+
+# === AI Assistant CLIENT ===
+
+class AIAssistantAPIClient:
+    """Client for the simple AI assistant endpoint."""
+
+    def __init__(self, base_url: str = "http://localhost:8000/api"):
+        self.base_url = base_url.rstrip("/")
+
+    def ask(self, prompt: str) -> Dict[str, Any]:
+        resp = requests.post(
+            f"{self.base_url}/assistant/chat",
+            json={"prompt": prompt},
+            timeout=6,
+        )
+        if resp.status_code != 200:
+            raise APIError(f"HTTP {resp.status_code}: {resp.text}")
+        return resp.json()
+
+    def ask_async(
+        self,
+        prompt: str,
+        on_success: Callable[[Dict[str, Any]], None],
+        on_error: Callable[[Exception], None],
+    ) -> None:
+        def _task():
+            try:
+                data = self.ask(prompt)
+                GLib.idle_add(on_success, data)
+            except Exception as exc:
+                GLib.idle_add(on_error, exc)
+
+        threading.Thread(target=_task, daemon=True).start()

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -9,6 +9,8 @@ try:
     from .views.attack_view import AttackView
     from .views.settings_view import SettingsView
     from .views.dashboard_view import DashboardView
+    from .views.packetforge_view import PacketForgeView
+    from .views.aiassistant_view import AIAssistantView
 except ImportError:
     import os
     import sys
@@ -20,6 +22,8 @@ except ImportError:
     from frontend.views.attack_view import AttackView
     from frontend.views.settings_view import SettingsView
     from frontend.views.dashboard_view import DashboardView
+    from frontend.views.packetforge_view import PacketForgeView
+    from frontend.views.aiassistant_view import AIAssistantView
 
 class ZeusApp(Gtk.Application):
     """Main GTK application class."""
@@ -44,6 +48,8 @@ class ZeusAppWindow(Gtk.ApplicationWindow):
         self.notebook = Gtk.Notebook()
         self.network_view = NetworkView(parent_controller=self)
         self.attack_view = AttackView()
+        self.packet_forge_view = PacketForgeView()
+        self.ai_assistant_view = AIAssistantView()
         self.settings_view = SettingsView()
         self.dashboard_view = DashboardView()
 
@@ -51,6 +57,8 @@ class ZeusAppWindow(Gtk.ApplicationWindow):
 
         self.notebook.append_page(self.network_view, Gtk.Label(label="Networks"))
         self.notebook.append_page(self.attack_view, Gtk.Label(label="Attack"))
+        self.notebook.append_page(self.packet_forge_view, Gtk.Label(label="Packet Forge"))
+        self.notebook.append_page(self.ai_assistant_view, Gtk.Label(label="AI Assistant"))
         self.notebook.append_page(self.settings_view, Gtk.Label(label="Settings"))
         self.notebook.append_page(self.dashboard_view, Gtk.Label(label="Dashboard"))
 

--- a/frontend/views/aiassistant_view.py
+++ b/frontend/views/aiassistant_view.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""AI Assistant tab providing simple chat interface."""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+
+try:
+    from backend.services.api_client import AIAssistantAPIClient
+except ImportError:  # pragma: no cover
+    import os
+    import sys
+    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+    PARENT_DIR = os.path.dirname(CURRENT_DIR)
+    GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
+    if GRANDPARENT_DIR not in sys.path:
+        sys.path.insert(0, GRANDPARENT_DIR)
+    from backend.services.api_client import AIAssistantAPIClient
+
+
+class AIAssistantView(Gtk.Box):
+    """Basic AI chat view backed by the ZeusNet API."""
+
+    def __init__(self) -> None:
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        self.set_margin_top(12)
+        self.set_margin_bottom(12)
+        self.set_margin_start(12)
+        self.set_margin_end(12)
+
+        self.api_client = AIAssistantAPIClient()
+
+        self.chat_view = Gtk.TextView()
+        self.chat_view.set_editable(False)
+        self.chat_view.set_wrap_mode(Gtk.WrapMode.WORD)
+        self.chat_buffer = self.chat_view.get_buffer()
+
+        input_box = Gtk.Box(spacing=6)
+        self.entry = Gtk.Entry()
+        send_btn = Gtk.Button(label="Send")
+        send_btn.connect("clicked", self.on_send)
+        input_box.append(self.entry)
+        input_box.append(send_btn)
+
+        self.append(self.chat_view)
+        self.append(input_box)
+
+    def _append_text(self, text: str) -> None:
+        end = self.chat_buffer.get_end_iter()
+        self.chat_buffer.insert(end, text)
+        mark = self.chat_buffer.get_insert()
+        self.chat_view.scroll_to_mark(mark, 0.05, True, 0.0, 1.0)
+
+    def on_send(self, _btn: Gtk.Button) -> None:
+        prompt = self.entry.get_text()
+        if not prompt:
+            return
+        self.entry.set_text("")
+        self._append_text(f"You: {prompt}\n")
+
+        def _on_success(data: dict) -> None:
+            self._append_text(f"AI: {data.get('response', '')}\n")
+
+        def _on_error(err: Exception) -> None:
+            self._append_text(f"Error: {err}\n")
+
+        self.api_client.ask_async(prompt, _on_success, _on_error)

--- a/frontend/views/packetforge_view.py
+++ b/frontend/views/packetforge_view.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Packet Forge tab for crafting custom packets."""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+
+try:
+    from backend.services.api_client import ForgeAPIClient
+except ImportError:  # pragma: no cover - fallback when run directly
+    import os
+    import sys
+    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+    PARENT_DIR = os.path.dirname(CURRENT_DIR)
+    GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
+    if GRANDPARENT_DIR not in sys.path:
+        sys.path.insert(0, GRANDPARENT_DIR)
+    from backend.services.api_client import ForgeAPIClient
+
+
+class PacketForgeView(Gtk.Box):
+    """Simple UI for sending crafted packets via backend API."""
+
+    def __init__(self) -> None:
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.set_margin_top(12)
+        self.set_margin_bottom(12)
+        self.set_margin_start(12)
+        self.set_margin_end(12)
+
+        self.api_client = ForgeAPIClient()
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        form = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+
+        # Frame type
+        type_row = Gtk.Box(spacing=6)
+        type_row.append(Gtk.Label(label="Frame Type:", xalign=0))
+        self.type_entry = Gtk.Entry()
+        type_row.append(self.type_entry)
+        form.append(type_row)
+
+        # Payload
+        payload_row = Gtk.Box(spacing=6)
+        payload_row.append(Gtk.Label(label="Payload:", xalign=0))
+        self.payload_entry = Gtk.Entry()
+        payload_row.append(self.payload_entry)
+        form.append(payload_row)
+
+        send_btn = Gtk.Button(label="Send Packet")
+        send_btn.connect("clicked", self.on_send)
+        form.append(send_btn)
+
+        self.status_label = Gtk.Label(label="", xalign=0)
+        form.append(self.status_label)
+
+        self.append(form)
+
+    def on_send(self, _btn: Gtk.Button) -> None:
+        frame_type = self.type_entry.get_text()
+        payload = self.payload_entry.get_text()
+        self.status_label.set_text("Sending packet...")
+
+        def _on_success(data: dict) -> None:
+            self.status_label.set_text(data.get("status", "sent"))
+
+        def _on_error(err: Exception) -> None:
+            self.status_label.set_text(f"Error: {err}")
+
+        self.api_client.send_packet_async(frame_type, payload, _on_success, _on_error)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,12 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 # Import routers and settings
-from backend.api import networks, settings as settings_api
+from backend.api import (
+    networks,
+    settings as settings_api,
+    forge,
+    assistant,
+)
 from backend.db import init_db
 import backend.settings as config
 
@@ -16,6 +21,8 @@ def client():
     app = FastAPI()
     app.include_router(networks.router, prefix="/api")
     app.include_router(settings_api.router, prefix="/api")
+    app.include_router(forge.router, prefix="/api")
+    app.include_router(assistant.router, prefix="/api")
     with TestClient(app) as c:
         yield c
 
@@ -53,3 +60,17 @@ def test_aggressive_mode_updates_network_fields(client):
     assert items
     item = items[0]
     assert {"bssid", "auth", "channel", "timestamp"} <= item.keys()
+
+
+def test_forge_send(client):
+    resp = client.post("/api/forge/send", json={"frame_type": "beacon", "payload": "test"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "sent"
+    assert data["frame_type"] == "beacon"
+
+
+def test_assistant_chat(client):
+    resp = client.post("/api/assistant/chat", json={"prompt": "hello"})
+    assert resp.status_code == 200
+    assert resp.json()["response"] == "olleh"


### PR DESCRIPTION
## Summary
- add PacketForge and AI Assistant API routers
- extend backend main router registration
- add GTK views for PacketForge and AI Assistant
- expose new API clients
- wire new tabs into frontend app
- cover new endpoints with tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f925d10308324a88b85e43cde97b8