### PR TITLE
Add Figma handoff instructions

### DIFF
--- a/backend/core/agent_manager.py
+++ b/backend/core/agent_manager.py
@@ -1,0 +1,61 @@
+import logging
+from typing import List
+
+from backend.c2.command_bus import command_bus
+from backend.agents.zeus_relay import ZeusRelay
+from backend.agents.signal_watcher import SignalWatcher
+from backend.agents.map_intel import MapIntelligence
+from backend.agents.anomaly_guard import AnomalyGuard
+from backend.agents.command_hub import CommandHub
+
+logger = logging.getLogger("agent_manager")
+
+
+class AgentManager:
+    """Simple container that owns and starts ZeusNet agents."""
+
+    def __init__(self) -> None:
+        self.agents: List[object] = []
+
+    def register(self, agent: object) -> None:
+        """Register an agent instance."""
+        self.agents.append(agent)
+
+    def start_all(self) -> None:
+        """Start each agent if it exposes a ``start`` method."""
+        for agent in self.agents:
+            start_fn = getattr(agent, "start", None)
+            if callable(start_fn):
+                try:
+                    start_fn()
+                    logger.info("Started %s", agent.__class__.__name__)
+                except Exception as exc:
+                    logger.error("Failed to start %s: %s", agent.__class__.__name__, exc)
+
+    def stop_all(self) -> None:
+        """Stop agents that expose a ``stop`` method."""
+        for agent in self.agents:
+            stop_fn = getattr(agent, "stop", None)
+            if callable(stop_fn):
+                try:
+                    stop_fn()
+                    logger.info("Stopped %s", agent.__class__.__name__)
+                except Exception as exc:
+                    logger.error("Failed to stop %s: %s", agent.__class__.__name__, exc)
+
+
+def create_default_manager() -> AgentManager:
+    """Instantiate the built-in ZeusNet agents with the shared command bus."""
+    bus = command_bus
+
+    manager = AgentManager()
+    manager.register(ZeusRelay(bus))
+    manager.register(SignalWatcher(bus))
+    manager.register(MapIntelligence())
+    manager.register(AnomalyGuard())
+    manager.register(CommandHub())
+    return manager
+
+
+# Export default manager instance
+agent_manager = create_default_manager()

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,7 +23,7 @@ from backend.routes import networks as route_networks
 from backend.routes import settings as route_settings
 from backend.routes import nic as route_nic
 
-from backend.c2.command_bus import start_bus
+from backend.core.agent_manager import agent_manager
 from backend.db import init_db
 
 # 🚀 FastAPI app
@@ -78,4 +78,4 @@ app.include_router(route_nic.router)
 @app.on_event("startup")
 def _startup():
     init_db()
-    start_bus()
+    agent_manager.start_all()

--- a/docs/dev-handoff.md
+++ b/docs/dev-handoff.md
@@ -1,0 +1,44 @@
+# ZEUSNET Figma Handoff
+
+This document outlines how to prepare and export the ZeusNet UI designs from Figma for developers.
+
+## Layout & Spacing
+- Base frame width: **1440 px** desktop.
+- Use an **8 px** spacing grid for consistent padding and margins.
+- Each tool module should follow a **Form on the Left, Output on the Right** layout.
+
+## Components to Build
+Create shared components in a Figma library so that screens can reuse them:
+- **TopBar** – fixed header with mode toggle and quick stats.
+- **SideNav** – collapsible navigation with icons and labels.
+- **MainContentWrapper** – container for page modules.
+- **LogConsole** – sticky footer that streams logs.
+- **ModalTemplate** – generic dialog for confirmations and warnings.
+- **FormFields** – consistent input styles.
+- **StatusCards** – metric cards for interfaces or scans.
+- **AttackFormLayout** – command inputs with progress feedback.
+
+## Page Frames
+Create separate frames named exactly as listed below:
+- `Dashboard`
+- `Scan`
+- `Networks`
+- `Devices`
+- `Attack_Probe`
+- `Attack_SYN`
+- `Attack_Aire`
+- `Alerts`
+- `Export`
+- `Settings`
+
+These names will be used when exporting assets.
+
+## Design Notes
+- Include layers that respond to `ZEUSNET_MODE` to show disabled states when the application runs in **SAFE** mode.
+- Enable **Dev Mode** in Figma so developers can read Tailwind-compatible class hints and CSS variables.
+
+## Export Instructions
+1. Export each frame as PNG/SVG and name the files to match the frame titles.
+2. Publish shared components to the Figma Library for reuse.
+3. Provide the team with the Figma link and ensure Dev Mode is enabled for inspection.
+


### PR DESCRIPTION
## Summary
- add design handoff notes for creating ZeusNet UI in Figma
- introduce AgentManager for starting all agents at app startup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_686f29a5d0188324a6141cce7a493db5