### PR TITLE
Fix missing imports in networks route

### DIFF
--- a/backend/routes/networks.py
+++ b/backend/routes/networks.py
@@ -1,6 +1,9 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from backend.db import get_db
+from backend.models import WiFiScan
+
 router = APIRouter()
 
 


### PR DESCRIPTION
## Summary
- import `get_db` and `WiFiScan` in `backend/routes/networks.py`

## Testing
- `ruff check .` *(fails: module-level import order, undefined modules)*
- `black --check .` *(fails: would reformat many files)*
- `prettier --check "js/**/*.{js,ts}"` *(fails: no matching files)*
- `pytest` *(fails: ModuleNotFoundError: fastapi)*
- `( cd js && npm test )` *(fails: no such directory)*

------
https://chatgpt.com/codex/tasks/task_e_686fabdc80e483248e3f17b91290cfa0