### PR TITLE
Fix missing imports in frontend

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -3,11 +3,14 @@
 import gi
 
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk 
+from gi.repository import Gtk
 from .views.network_view import NetworkView
 from .views.attack_view import AttackView
+from .views.packetforge_view import PacketForgeView
+from .views.aiassistant_view import AIAssistantView
 from .views.settings_view import SettingsView
 from .views.dashboard_view import DashboardView
+
 
 class ZeusApp(Gtk.Application):
     """Main GTK application class."""
@@ -42,8 +45,12 @@ class ZeusAppWindow(Gtk.ApplicationWindow):
 
         self.notebook.append_page(self.network_view, Gtk.Label(label="Networks"))
         self.notebook.append_page(self.attack_view, Gtk.Label(label="Attack"))
-        self.notebook.append_page(self.packet_forge_view, Gtk.Label(label="Packet Forge"))
-        self.notebook.append_page(self.ai_assistant_view, Gtk.Label(label="AI Assistant"))
+        self.notebook.append_page(
+            self.packet_forge_view, Gtk.Label(label="Packet Forge")
+        )
+        self.notebook.append_page(
+            self.ai_assistant_view, Gtk.Label(label="AI Assistant")
+        )
         self.notebook.append_page(self.settings_view, Gtk.Label(label="Settings"))
         self.notebook.append_page(self.dashboard_view, Gtk.Label(label="Dashboard"))
 


### PR DESCRIPTION
## Summary
- import PacketForgeView and AIAssistantView in `frontend/app.py`

## Testing
- `ruff check frontend/app.py`
- `black --check frontend/app.py`
- `pytest`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686fb071f96c8324b9249d4ca97d10f5