### PR TITLE
Fix prettier check path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             npm install
           fi
       - name: Prettier check
-        run: npx prettier --check "webui/**/*.{js,jsx,ts,tsx}"
+        run: prettier --check "webui/**/*.{js,jsx,ts,tsx}"
       - name: Jest
         run: npm test --if-present
       - name: Jest coverage check

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -53,6 +53,12 @@ npm install
 npm run dev
 ```
 
+To check formatting of the React sources, run Prettier:
+
+```bash
+prettier --check "webui/**/*.{js,jsx,ts,tsx}"
+```
+
 ### ⚙️ Enable systemd Service (Optional)
 
 ```bash


### PR DESCRIPTION
## Summary
- run prettier on `webui/` in CI
- document how to run Prettier for the React UI

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 25 files)*
- `prettier --check "webui/**/*.{js,jsx,ts,tsx}"` *(fails: code style issues found)*
- `pytest`
- `(cd webui && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_686fb0cae2e8832493f3742c48c4cef6