### PR TITLE
Add Ruff configuration

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,2 @@
+[lint]
+ignore = ["E402"]


### PR DESCRIPTION
## Summary
- ignore E402 errors globally by adding `.ruff.toml`

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 25 files)*
- `prettier --check "webui/**/*.{js,jsx,ts,tsx}"` *(fails: issues found in 5 files)*
- `pytest -q`
- `(cd webui && npm test --silent)`

------
https://chatgpt.com/codex/tasks/task_e_686fb0726c4c83248cbdf815449fab01