### PR TITLE
Configure Vite base path for relative assets

### DIFF
--- a/frontend/main.py
+++ b/frontend/main.py
@@ -13,12 +13,14 @@ except ImportError:  # pragma: no cover - allow running directly
     from frontend.utils.path_setup import ensure_repo_root_on_path
 
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gtk, Gdk 
+from gi.repository import Gtk, Gdk
+
 # Allow running as "python frontend/main.py" by adding repo root
 if __package__ is None:
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-    
+
 from frontend.utils.path_setup import ensure_repo_root_on_path
+
 ensure_repo_root_on_path()
 
 # --- CSS LOADER: Load custom style before any windows ---

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -18,7 +18,10 @@ export default function App() {
   const [logLines, setLogLines] = useState([]);
 
   const log = (msg) =>
-    setLogLines((lines) => [...lines, `[${new Date().toLocaleTimeString()}] ${msg}`]);
+    setLogLines((lines) => [
+      ...lines,
+      `[${new Date().toLocaleTimeString()}] ${msg}`,
+    ]);
 
   const renderTab = () => {
     switch (activeTab) {

--- a/webui/src/components/NetworkOpsPanel.jsx
+++ b/webui/src/components/NetworkOpsPanel.jsx
@@ -11,7 +11,7 @@ export default function NetworkOpsPanel({ log }) {
     e.preventDefault();
     setLoading(true);
     log(
-      `\ud83d\udce1 Initiating ${operation.replace("_", " ").toUpperCase()} on ${targetId} (Ch ${channel})`
+      `\ud83d\udce1 Initiating ${operation.replace("_", " ").toUpperCase()} on ${targetId} (Ch ${channel})`,
     );
 
     try {

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -7,5 +7,5 @@ import { SettingsProvider } from "./utils/SettingsContext";
 ReactDOM.createRoot(document.getElementById("root")).render(
   <SettingsProvider>
     <App />
-  </SettingsProvider>
+  </SettingsProvider>,
 );

--- a/webui/src/utils/apiClient.js
+++ b/webui/src/utils/apiClient.js
@@ -15,7 +15,7 @@ apiClient.interceptors.response.use(
   (err) => {
     const message = err.response?.data?.detail || err.message;
     return Promise.reject(new Error(message));
-  }
+  },
 );
 
 export default apiClient;

--- a/webui/vite.config.js
+++ b/webui/vite.config.js
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  base: "./",
   plugins: [react()],
   server: {
     port: 5173,
   },
-})
+});


### PR DESCRIPTION
## Summary
- set Vite `base` option so built assets resolve relative to the deployment directory
- format source files to satisfy project linters

## Testing
- `ruff check .`
- `black --check .`
- `prettier --check "webui/**/*.{js,jsx,ts,tsx}"`
- `pytest`
- `cd webui && npm test`
- `cd webui && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895e085f1e483249b8f41e723eb4c2e